### PR TITLE
Interface segregation based on Accedo One endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
+AccedoOneiOS/AccedoOneiOS.xcodeproj/project.xcworkspace/xcuserdata/stephen.xcuserdatad/
+AccedoOneiOS/AccedoOneiOS.xcodeproj/xcuserdata/stephen.xcuserdatad/
+AccedoOnetvOS/AccedoOnetvOS.xcodeproj/project.xcworkspace/xcuserdata/stephen.xcuserdatad/
+AccedoOnetvOS/AccedoOnetvOS.xcodeproj/xcuserdata/stephen.xcuserdatad/
 /Binary/*

--- a/AccedoOneiOS/AccedoOneiOS.xcodeproj/project.pbxproj
+++ b/AccedoOneiOS/AccedoOneiOS.xcodeproj/project.pbxproj
@@ -30,56 +30,62 @@
 		8CE8C72D1FEC7A4D0041C284 /* AccedoOne.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CE8C7271FEC7A4D0041C284 /* AccedoOne.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8CE8C72E1FEC7A4D0041C284 /* AccedoOne.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CE8C7281FEC7A4D0041C284 /* AccedoOne.m */; };
 		8CE8C7321FEC7AD60041C284 /* AccedoOneiOS.pch in Headers */ = {isa = PBXBuildFile; fileRef = 8CE8C7311FEC7AD60041C284 /* AccedoOneiOS.pch */; };
-		8CE8C73C1FEC7D340041C284 /* AOCacheDTO.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CE8C7351FEC7D340041C284 /* AOCacheDTO.h */; };
-		8CE8C73D1FEC7D340041C284 /* AOCacheDTO.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CE8C7361FEC7D340041C284 /* AOCacheDTO.m */; };
-		8CE8C73E1FEC7D340041C284 /* AOCacheHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CE8C7371FEC7D340041C284 /* AOCacheHelper.m */; };
-		8CE8C73F1FEC7D340041C284 /* AOService+CacheController.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CE8C7381FEC7D340041C284 /* AOService+CacheController.h */; };
-		8CE8C7401FEC7D340041C284 /* AOService+CacheController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CE8C7391FEC7D340041C284 /* AOService+CacheController.m */; };
-		8CE8C7411FEC7D340041C284 /* AOCacheHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CE8C73A1FEC7D340041C284 /* AOCacheHelper.h */; };
-		8CE8C7421FEC7D340041C284 /* AOCacheHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CE8C73B1FEC7D340041C284 /* AOCacheHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8CE8C74A1FEC7D5B0041C284 /* AOCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CE8C7441FEC7D5A0041C284 /* AOCache.m */; };
-		8CE8C74B1FEC7D5B0041C284 /* AOCacheOverNSCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CE8C7451FEC7D5A0041C284 /* AOCacheOverNSCache.m */; };
-		8CE8C74C1FEC7D5B0041C284 /* AOCacheOverPINCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CE8C7461FEC7D5A0041C284 /* AOCacheOverPINCache.h */; };
-		8CE8C74D1FEC7D5B0041C284 /* AOCacheOverPINCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CE8C7471FEC7D5A0041C284 /* AOCacheOverPINCache.m */; };
-		8CE8C74E1FEC7D5B0041C284 /* AOCacheOverNSCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CE8C7481FEC7D5B0041C284 /* AOCacheOverNSCache.h */; };
-		8CE8C74F1FEC7D5B0041C284 /* AOCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CE8C7491FEC7D5B0041C284 /* AOCache.h */; };
-		8CE8C7531FEC7D730041C284 /* AOCacheAtom.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CE8C7511FEC7D730041C284 /* AOCacheAtom.h */; };
-		8CE8C7541FEC7D730041C284 /* AOCacheAtom.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CE8C7521FEC7D730041C284 /* AOCacheAtom.m */; };
-		8CE8C75C1FEC7DB50041C284 /* AOPagingMetadata.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CE8C7581FEC7DB50041C284 /* AOPagingMetadata.m */; };
-		8CE8C75D1FEC7DB50041C284 /* AOPagingMetadata.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CE8C7591FEC7DB50041C284 /* AOPagingMetadata.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8CE8C75E1FEC7DB50041C284 /* AORequestMetadata.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CE8C75A1FEC7DB50041C284 /* AORequestMetadata.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8CE8C75F1FEC7DB50041C284 /* AORequestMetadata.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CE8C75B1FEC7DB50041C284 /* AORequestMetadata.m */; };
-		8CE8C7671FEC7DC80041C284 /* AOCMSOptionalParams.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CE8C7601FEC7DC80041C284 /* AOCMSOptionalParams.m */; };
-		8CE8C7681FEC7DC80041C284 /* AOServiceComponent.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CE8C7611FEC7DC80041C284 /* AOServiceComponent.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8CE8C7691FEC7DC80041C284 /* AOService.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CE8C7621FEC7DC80041C284 /* AOService.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8CE8C76A1FEC7DC80041C284 /* AOObjectParserProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CE8C7631FEC7DC80041C284 /* AOObjectParserProtocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8CE8C76B1FEC7DC80041C284 /* AOService.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CE8C7641FEC7DC80041C284 /* AOService.m */; };
-		8CE8C76C1FEC7DC80041C284 /* AOCMSOptionalParams.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CE8C7651FEC7DC80041C284 /* AOCMSOptionalParams.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8CE8C76D1FEC7DC80041C284 /* AOServiceComponent.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CE8C7661FEC7DC80041C284 /* AOServiceComponent.m */; };
-		8CE8C7781FEC7DD90041C284 /* AOAsynchBlockOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CE8C76E1FEC7DD90041C284 /* AOAsynchBlockOperation.m */; };
-		8CE8C7791FEC7DD90041C284 /* AOError.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CE8C76F1FEC7DD90041C284 /* AOError.m */; };
-		8CE8C77A1FEC7DD90041C284 /* AOFileUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CE8C7701FEC7DD90041C284 /* AOFileUtils.m */; };
-		8CE8C77B1FEC7DD90041C284 /* AOError.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CE8C7711FEC7DD90041C284 /* AOError.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8CE8C77C1FEC7DD90041C284 /* NSString+AO.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CE8C7721FEC7DD90041C284 /* NSString+AO.m */; };
-		8CE8C77D1FEC7DD90041C284 /* NSArray+AO.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CE8C7731FEC7DD90041C284 /* NSArray+AO.h */; };
-		8CE8C77E1FEC7DD90041C284 /* NSArray+AO.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CE8C7741FEC7DD90041C284 /* NSArray+AO.m */; };
-		8CE8C77F1FEC7DD90041C284 /* AOAsynchBlockOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CE8C7751FEC7DD90041C284 /* AOAsynchBlockOperation.h */; };
-		8CE8C7801FEC7DD90041C284 /* NSString+AO.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CE8C7761FEC7DD90041C284 /* NSString+AO.h */; };
-		8CE8C7811FEC7DD90041C284 /* AOFileUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CE8C7771FEC7DD90041C284 /* AOFileUtils.h */; };
-		8CF755A81FED3B1C000D7070 /* AccedoOneInsight.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CF7559E1FED3B1C000D7070 /* AccedoOneInsight.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8CF755A91FED3B1C000D7070 /* AccedoOneUserData.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CF7559F1FED3B1C000D7070 /* AccedoOneUserData.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8CF755AA1FED3B1C000D7070 /* AccedoOneInsight.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CF755A01FED3B1C000D7070 /* AccedoOneInsight.m */; };
-		8CF755AB1FED3B1C000D7070 /* AccedoOneDetect.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CF755A11FED3B1C000D7070 /* AccedoOneDetect.m */; };
-		8CF755AC1FED3B1C000D7070 /* AccedoOneDetect.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CF755A21FED3B1C000D7070 /* AccedoOneDetect.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8CF755AD1FED3B1C000D7070 /* AccedoOneControl.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CF755A31FED3B1C000D7070 /* AccedoOneControl.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8CF755AE1FED3B1C000D7070 /* AccedoOnePublish.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CF755A41FED3B1C000D7070 /* AccedoOnePublish.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8CF755AF1FED3B1C000D7070 /* AccedoOneControl.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CF755A51FED3B1C000D7070 /* AccedoOneControl.m */; };
-		8CF755B01FED3B1C000D7070 /* AccedoOneUserData.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CF755A61FED3B1C000D7070 /* AccedoOneUserData.m */; };
-		8CF755B11FED3B1C000D7070 /* AccedoOnePublish.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CF755A71FED3B1C000D7070 /* AccedoOnePublish.m */; };
 		99C686DC93237DA650EEC259 /* AFSecurityPolicy.m in Sources */ = {isa = PBXBuildFile; fileRef = DA91C2237F337B093C57119D /* AFSecurityPolicy.m */; };
 		A9AE262560AD26F480AE3463 /* AFURLRequestSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = CE9B4DE1AAF01CB0D6672CB7 /* AFURLRequestSerialization.m */; };
 		B5191C5DFD056582A4B66F3F /* PINCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 0993505D5359BC782139DBFB /* PINCache.m */; };
 		D7EE5BC22059A408CFBD01A4 /* AFURLSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 91179B011F41F1738620BBCF /* AFURLSessionManager.m */; };
+		DC2AD3C02020832900C9FC61 /* AOCacheDTO.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD38B2020832800C9FC61 /* AOCacheDTO.h */; };
+		DC2AD3C12020832900C9FC61 /* AOService+CacheController.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD38C2020832800C9FC61 /* AOService+CacheController.h */; };
+		DC2AD3C22020832900C9FC61 /* AOCacheHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = DC2AD38D2020832800C9FC61 /* AOCacheHelper.m */; };
+		DC2AD3C32020832900C9FC61 /* AOCache.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD38F2020832800C9FC61 /* AOCache.h */; };
+		DC2AD3C42020832900C9FC61 /* AOCacheOverNSCache.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD3902020832800C9FC61 /* AOCacheOverNSCache.h */; };
+		DC2AD3C52020832900C9FC61 /* AOCacheOverPINCache.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD3912020832800C9FC61 /* AOCacheOverPINCache.h */; };
+		DC2AD3C62020832900C9FC61 /* AOCacheAtom.m in Sources */ = {isa = PBXBuildFile; fileRef = DC2AD3932020832800C9FC61 /* AOCacheAtom.m */; };
+		DC2AD3C72020832900C9FC61 /* AOCacheAtom.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD3942020832800C9FC61 /* AOCacheAtom.h */; };
+		DC2AD3C82020832900C9FC61 /* AOCacheOverPINCache.m in Sources */ = {isa = PBXBuildFile; fileRef = DC2AD3952020832800C9FC61 /* AOCacheOverPINCache.m */; };
+		DC2AD3C92020832900C9FC61 /* AOCacheOverNSCache.m in Sources */ = {isa = PBXBuildFile; fileRef = DC2AD3962020832800C9FC61 /* AOCacheOverNSCache.m */; };
+		DC2AD3CA2020832900C9FC61 /* AOCache.m in Sources */ = {isa = PBXBuildFile; fileRef = DC2AD3972020832800C9FC61 /* AOCache.m */; };
+		DC2AD3CB2020832900C9FC61 /* AOService+CacheController.m in Sources */ = {isa = PBXBuildFile; fileRef = DC2AD3982020832800C9FC61 /* AOService+CacheController.m */; };
+		DC2AD3CC2020832900C9FC61 /* AOCacheDTO.m in Sources */ = {isa = PBXBuildFile; fileRef = DC2AD3992020832800C9FC61 /* AOCacheDTO.m */; };
+		DC2AD3CD2020832900C9FC61 /* AOCacheHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD39A2020832800C9FC61 /* AOCacheHelper.h */; };
+		DC2AD3CE2020832900C9FC61 /* AOCacheHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD39B2020832800C9FC61 /* AOCacheHandler.h */; };
+		DC2AD3CF2020832900C9FC61 /* AORequestMetadata.m in Sources */ = {isa = PBXBuildFile; fileRef = DC2AD39D2020832900C9FC61 /* AORequestMetadata.m */; };
+		DC2AD3D02020832900C9FC61 /* AOPagingMetadata.m in Sources */ = {isa = PBXBuildFile; fileRef = DC2AD39E2020832900C9FC61 /* AOPagingMetadata.m */; };
+		DC2AD3D12020832900C9FC61 /* AOPagingMetadata.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD39F2020832900C9FC61 /* AOPagingMetadata.h */; };
+		DC2AD3D22020832900C9FC61 /* AORequestMetadata.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD3A02020832900C9FC61 /* AORequestMetadata.h */; };
+		DC2AD3D32020832900C9FC61 /* AccedoOneControl.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD3A22020832900C9FC61 /* AccedoOneControl.h */; };
+		DC2AD3D42020832900C9FC61 /* AccedoOnePublish.m in Sources */ = {isa = PBXBuildFile; fileRef = DC2AD3A32020832900C9FC61 /* AccedoOnePublish.m */; };
+		DC2AD3D52020832900C9FC61 /* AccedoOneInsight.m in Sources */ = {isa = PBXBuildFile; fileRef = DC2AD3A42020832900C9FC61 /* AccedoOneInsight.m */; };
+		DC2AD3D62020832900C9FC61 /* AccedoOneDetect.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD3A52020832900C9FC61 /* AccedoOneDetect.h */; };
+		DC2AD3D72020832900C9FC61 /* AccedoOneUserData.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD3A62020832900C9FC61 /* AccedoOneUserData.h */; };
+		DC2AD3D82020832900C9FC61 /* AccedoOneControl.m in Sources */ = {isa = PBXBuildFile; fileRef = DC2AD3A72020832900C9FC61 /* AccedoOneControl.m */; };
+		DC2AD3D92020832900C9FC61 /* AccedoOneInsight.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD3A82020832900C9FC61 /* AccedoOneInsight.h */; };
+		DC2AD3DA2020832900C9FC61 /* AccedoOnePublish.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD3A92020832900C9FC61 /* AccedoOnePublish.h */; };
+		DC2AD3DB2020832900C9FC61 /* AccedoOneDetect.m in Sources */ = {isa = PBXBuildFile; fileRef = DC2AD3AA2020832900C9FC61 /* AccedoOneDetect.m */; };
+		DC2AD3DC2020832900C9FC61 /* AccedoOneUserData.m in Sources */ = {isa = PBXBuildFile; fileRef = DC2AD3AB2020832900C9FC61 /* AccedoOneUserData.m */; };
+		DC2AD3DD2020832900C9FC61 /* AOService.m in Sources */ = {isa = PBXBuildFile; fileRef = DC2AD3AE2020832900C9FC61 /* AOService.m */; };
+		DC2AD3DE2020832900C9FC61 /* AOServiceComponent.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD3AF2020832900C9FC61 /* AOServiceComponent.h */; };
+		DC2AD3DF2020832900C9FC61 /* AOCMSOptionalParams.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD3B02020832900C9FC61 /* AOCMSOptionalParams.h */; };
+		DC2AD3E02020832900C9FC61 /* AOService.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD3B12020832900C9FC61 /* AOService.h */; };
+		DC2AD3E12020832900C9FC61 /* AOCMSOptionalParams.m in Sources */ = {isa = PBXBuildFile; fileRef = DC2AD3B22020832900C9FC61 /* AOCMSOptionalParams.m */; };
+		DC2AD3E22020832900C9FC61 /* AOServiceComponent.m in Sources */ = {isa = PBXBuildFile; fileRef = DC2AD3B32020832900C9FC61 /* AOServiceComponent.m */; };
+		DC2AD3E32020832900C9FC61 /* AOObjectParserProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD3B42020832900C9FC61 /* AOObjectParserProtocol.h */; };
+		DC2AD3E42020832900C9FC61 /* AOError.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD3B62020832900C9FC61 /* AOError.h */; };
+		DC2AD3E52020832900C9FC61 /* AOAsynchBlockOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD3B72020832900C9FC61 /* AOAsynchBlockOperation.h */; };
+		DC2AD3E62020832900C9FC61 /* NSString+AO.m in Sources */ = {isa = PBXBuildFile; fileRef = DC2AD3B82020832900C9FC61 /* NSString+AO.m */; };
+		DC2AD3E72020832900C9FC61 /* AOFileUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = DC2AD3B92020832900C9FC61 /* AOFileUtils.m */; };
+		DC2AD3E82020832900C9FC61 /* NSArray+AO.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD3BA2020832900C9FC61 /* NSArray+AO.h */; };
+		DC2AD3E92020832900C9FC61 /* AOError.m in Sources */ = {isa = PBXBuildFile; fileRef = DC2AD3BB2020832900C9FC61 /* AOError.m */; };
+		DC2AD3EA2020832900C9FC61 /* AOAsynchBlockOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = DC2AD3BC2020832900C9FC61 /* AOAsynchBlockOperation.m */; };
+		DC2AD3EB2020832900C9FC61 /* NSString+AO.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD3BD2020832900C9FC61 /* NSString+AO.h */; };
+		DC2AD3EC2020832900C9FC61 /* NSArray+AO.m in Sources */ = {isa = PBXBuildFile; fileRef = DC2AD3BE2020832900C9FC61 /* NSArray+AO.m */; };
+		DC2AD3ED2020832900C9FC61 /* AOFileUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD3BF2020832900C9FC61 /* AOFileUtils.h */; };
+		DC2AD3EF2020836700C9FC61 /* AccedoOneControlProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD3EE2020836700C9FC61 /* AccedoOneControlProtocol.h */; };
+		DC2AD3F12020837C00C9FC61 /* AccedoOneDetectProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD3F02020837C00C9FC61 /* AccedoOneDetectProtocol.h */; };
+		DC2AD3F32020839000C9FC61 /* AccedoOneInsightProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD3F22020839000C9FC61 /* AccedoOneInsightProtocol.h */; };
+		DC2AD3F5202083A000C9FC61 /* AccedoOnePublishProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD3F4202083A000C9FC61 /* AccedoOnePublishProtocol.h */; };
+		DC2AD3F7202083B200C9FC61 /* AccedoOneUserDataProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD3F6202083B200C9FC61 /* AccedoOneUserDataProtocol.h */; };
+		DC2AD3F9202083C800C9FC61 /* AccedoOneCacheProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD3F8202083C800C9FC61 /* AccedoOneCacheProtocol.h */; };
 		E7D5F4EB2FCFE7F1DFCF7100 /* PINDiskCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 3946882FFF12E2619D3A5703 /* PINDiskCache.m */; };
 		F98676B37884377F05E4376D /* PINMemoryCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 04E352377297CEDC4B64165F /* PINMemoryCache.m */; };
 /* End PBXBuildFile section */
@@ -115,52 +121,6 @@
 		8CE8C7271FEC7A4D0041C284 /* AccedoOne.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AccedoOne.h; path = ../../Common/AccedoOne.h; sourceTree = "<group>"; };
 		8CE8C7281FEC7A4D0041C284 /* AccedoOne.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AccedoOne.m; path = ../../Common/AccedoOne.m; sourceTree = "<group>"; };
 		8CE8C7311FEC7AD60041C284 /* AccedoOneiOS.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AccedoOneiOS.pch; sourceTree = "<group>"; };
-		8CE8C7351FEC7D340041C284 /* AOCacheDTO.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AOCacheDTO.h; path = ../../../Common/Cache/AOCacheDTO.h; sourceTree = "<group>"; };
-		8CE8C7361FEC7D340041C284 /* AOCacheDTO.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AOCacheDTO.m; path = ../../../Common/Cache/AOCacheDTO.m; sourceTree = "<group>"; };
-		8CE8C7371FEC7D340041C284 /* AOCacheHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AOCacheHelper.m; path = ../../../Common/Cache/AOCacheHelper.m; sourceTree = "<group>"; };
-		8CE8C7381FEC7D340041C284 /* AOService+CacheController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "AOService+CacheController.h"; path = "../../../Common/Cache/AOService+CacheController.h"; sourceTree = "<group>"; };
-		8CE8C7391FEC7D340041C284 /* AOService+CacheController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "AOService+CacheController.m"; path = "../../../Common/Cache/AOService+CacheController.m"; sourceTree = "<group>"; };
-		8CE8C73A1FEC7D340041C284 /* AOCacheHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AOCacheHelper.h; path = ../../../Common/Cache/AOCacheHelper.h; sourceTree = "<group>"; };
-		8CE8C73B1FEC7D340041C284 /* AOCacheHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AOCacheHandler.h; path = ../../../Common/Cache/AOCacheHandler.h; sourceTree = "<group>"; };
-		8CE8C7441FEC7D5A0041C284 /* AOCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AOCache.m; path = ../../../../Common/Cache/Providers/AOCache.m; sourceTree = "<group>"; };
-		8CE8C7451FEC7D5A0041C284 /* AOCacheOverNSCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AOCacheOverNSCache.m; path = ../../../../Common/Cache/Providers/AOCacheOverNSCache.m; sourceTree = "<group>"; };
-		8CE8C7461FEC7D5A0041C284 /* AOCacheOverPINCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AOCacheOverPINCache.h; path = ../../../../Common/Cache/Providers/AOCacheOverPINCache.h; sourceTree = "<group>"; };
-		8CE8C7471FEC7D5A0041C284 /* AOCacheOverPINCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AOCacheOverPINCache.m; path = ../../../../Common/Cache/Providers/AOCacheOverPINCache.m; sourceTree = "<group>"; };
-		8CE8C7481FEC7D5B0041C284 /* AOCacheOverNSCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AOCacheOverNSCache.h; path = ../../../../Common/Cache/Providers/AOCacheOverNSCache.h; sourceTree = "<group>"; };
-		8CE8C7491FEC7D5B0041C284 /* AOCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AOCache.h; path = ../../../../Common/Cache/Providers/AOCache.h; sourceTree = "<group>"; };
-		8CE8C7511FEC7D730041C284 /* AOCacheAtom.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AOCacheAtom.h; path = ../../../../../Common/Cache/Providers/Model/AOCacheAtom.h; sourceTree = "<group>"; };
-		8CE8C7521FEC7D730041C284 /* AOCacheAtom.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AOCacheAtom.m; path = ../../../../../Common/Cache/Providers/Model/AOCacheAtom.m; sourceTree = "<group>"; };
-		8CE8C7581FEC7DB50041C284 /* AOPagingMetadata.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AOPagingMetadata.m; path = ../../../Common/Request/AOPagingMetadata.m; sourceTree = "<group>"; };
-		8CE8C7591FEC7DB50041C284 /* AOPagingMetadata.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AOPagingMetadata.h; path = ../../../Common/Request/AOPagingMetadata.h; sourceTree = "<group>"; };
-		8CE8C75A1FEC7DB50041C284 /* AORequestMetadata.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AORequestMetadata.h; path = ../../../Common/Request/AORequestMetadata.h; sourceTree = "<group>"; };
-		8CE8C75B1FEC7DB50041C284 /* AORequestMetadata.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AORequestMetadata.m; path = ../../../Common/Request/AORequestMetadata.m; sourceTree = "<group>"; };
-		8CE8C7601FEC7DC80041C284 /* AOCMSOptionalParams.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AOCMSOptionalParams.m; path = ../../../Common/Service/AOCMSOptionalParams.m; sourceTree = "<group>"; };
-		8CE8C7611FEC7DC80041C284 /* AOServiceComponent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AOServiceComponent.h; path = ../../../Common/Service/AOServiceComponent.h; sourceTree = "<group>"; };
-		8CE8C7621FEC7DC80041C284 /* AOService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AOService.h; path = ../../../Common/Service/AOService.h; sourceTree = "<group>"; };
-		8CE8C7631FEC7DC80041C284 /* AOObjectParserProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AOObjectParserProtocol.h; path = ../../../Common/Service/AOObjectParserProtocol.h; sourceTree = "<group>"; };
-		8CE8C7641FEC7DC80041C284 /* AOService.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AOService.m; path = ../../../Common/Service/AOService.m; sourceTree = "<group>"; };
-		8CE8C7651FEC7DC80041C284 /* AOCMSOptionalParams.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AOCMSOptionalParams.h; path = ../../../Common/Service/AOCMSOptionalParams.h; sourceTree = "<group>"; };
-		8CE8C7661FEC7DC80041C284 /* AOServiceComponent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AOServiceComponent.m; path = ../../../Common/Service/AOServiceComponent.m; sourceTree = "<group>"; };
-		8CE8C76E1FEC7DD90041C284 /* AOAsynchBlockOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AOAsynchBlockOperation.m; path = ../../../Common/Utils/AOAsynchBlockOperation.m; sourceTree = "<group>"; };
-		8CE8C76F1FEC7DD90041C284 /* AOError.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AOError.m; path = ../../../Common/Utils/AOError.m; sourceTree = "<group>"; };
-		8CE8C7701FEC7DD90041C284 /* AOFileUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AOFileUtils.m; path = ../../../Common/Utils/AOFileUtils.m; sourceTree = "<group>"; };
-		8CE8C7711FEC7DD90041C284 /* AOError.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AOError.h; path = ../../../Common/Utils/AOError.h; sourceTree = "<group>"; };
-		8CE8C7721FEC7DD90041C284 /* NSString+AO.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSString+AO.m"; path = "../../../Common/Utils/NSString+AO.m"; sourceTree = "<group>"; };
-		8CE8C7731FEC7DD90041C284 /* NSArray+AO.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSArray+AO.h"; path = "../../../Common/Utils/NSArray+AO.h"; sourceTree = "<group>"; };
-		8CE8C7741FEC7DD90041C284 /* NSArray+AO.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSArray+AO.m"; path = "../../../Common/Utils/NSArray+AO.m"; sourceTree = "<group>"; };
-		8CE8C7751FEC7DD90041C284 /* AOAsynchBlockOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AOAsynchBlockOperation.h; path = ../../../Common/Utils/AOAsynchBlockOperation.h; sourceTree = "<group>"; };
-		8CE8C7761FEC7DD90041C284 /* NSString+AO.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSString+AO.h"; path = "../../../Common/Utils/NSString+AO.h"; sourceTree = "<group>"; };
-		8CE8C7771FEC7DD90041C284 /* AOFileUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AOFileUtils.h; path = ../../../Common/Utils/AOFileUtils.h; sourceTree = "<group>"; };
-		8CF7559E1FED3B1C000D7070 /* AccedoOneInsight.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AccedoOneInsight.h; path = ../../../Common/API/AccedoOneInsight.h; sourceTree = "<group>"; };
-		8CF7559F1FED3B1C000D7070 /* AccedoOneUserData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AccedoOneUserData.h; path = ../../../Common/API/AccedoOneUserData.h; sourceTree = "<group>"; };
-		8CF755A01FED3B1C000D7070 /* AccedoOneInsight.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AccedoOneInsight.m; path = ../../../Common/API/AccedoOneInsight.m; sourceTree = "<group>"; };
-		8CF755A11FED3B1C000D7070 /* AccedoOneDetect.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AccedoOneDetect.m; path = ../../../Common/API/AccedoOneDetect.m; sourceTree = "<group>"; };
-		8CF755A21FED3B1C000D7070 /* AccedoOneDetect.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AccedoOneDetect.h; path = ../../../Common/API/AccedoOneDetect.h; sourceTree = "<group>"; };
-		8CF755A31FED3B1C000D7070 /* AccedoOneControl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AccedoOneControl.h; path = ../../../Common/API/AccedoOneControl.h; sourceTree = "<group>"; };
-		8CF755A41FED3B1C000D7070 /* AccedoOnePublish.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AccedoOnePublish.h; path = ../../../Common/API/AccedoOnePublish.h; sourceTree = "<group>"; };
-		8CF755A51FED3B1C000D7070 /* AccedoOneControl.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AccedoOneControl.m; path = ../../../Common/API/AccedoOneControl.m; sourceTree = "<group>"; };
-		8CF755A61FED3B1C000D7070 /* AccedoOneUserData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AccedoOneUserData.m; path = ../../../Common/API/AccedoOneUserData.m; sourceTree = "<group>"; };
-		8CF755A71FED3B1C000D7070 /* AccedoOnePublish.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AccedoOnePublish.m; path = ../../../Common/API/AccedoOnePublish.m; sourceTree = "<group>"; };
 		9019A6B2A939F203E7A540DB /* AFHTTPSessionManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFHTTPSessionManager.h; path = AccedoOneiOS/Libraries/AFNetworking/AFHTTPSessionManager.h; sourceTree = "<group>"; };
 		91179B011F41F1738620BBCF /* AFURLSessionManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFURLSessionManager.m; path = AccedoOneiOS/Libraries/AFNetworking/AFURLSessionManager.m; sourceTree = "<group>"; };
 		9BC58D3048FDD380E70AFF6C /* Nullability.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Nullability.h; path = AccedoOneiOS/Libraries/PINCache/Nullability.h; sourceTree = "<group>"; };
@@ -170,6 +130,58 @@
 		C77FFC33A40DE0D76B1E2EFA /* AFNetworkReachabilityManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFNetworkReachabilityManager.h; path = AccedoOneiOS/Libraries/AFNetworking/AFNetworkReachabilityManager.h; sourceTree = "<group>"; };
 		CE9B4DE1AAF01CB0D6672CB7 /* AFURLRequestSerialization.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFURLRequestSerialization.m; path = AccedoOneiOS/Libraries/AFNetworking/AFURLRequestSerialization.m; sourceTree = "<group>"; };
 		DA91C2237F337B093C57119D /* AFSecurityPolicy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFSecurityPolicy.m; path = AccedoOneiOS/Libraries/AFNetworking/AFSecurityPolicy.m; sourceTree = "<group>"; };
+		DC2AD38B2020832800C9FC61 /* AOCacheDTO.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AOCacheDTO.h; sourceTree = "<group>"; };
+		DC2AD38C2020832800C9FC61 /* AOService+CacheController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "AOService+CacheController.h"; sourceTree = "<group>"; };
+		DC2AD38D2020832800C9FC61 /* AOCacheHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AOCacheHelper.m; sourceTree = "<group>"; };
+		DC2AD38F2020832800C9FC61 /* AOCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AOCache.h; sourceTree = "<group>"; };
+		DC2AD3902020832800C9FC61 /* AOCacheOverNSCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AOCacheOverNSCache.h; sourceTree = "<group>"; };
+		DC2AD3912020832800C9FC61 /* AOCacheOverPINCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AOCacheOverPINCache.h; sourceTree = "<group>"; };
+		DC2AD3932020832800C9FC61 /* AOCacheAtom.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AOCacheAtom.m; sourceTree = "<group>"; };
+		DC2AD3942020832800C9FC61 /* AOCacheAtom.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AOCacheAtom.h; sourceTree = "<group>"; };
+		DC2AD3952020832800C9FC61 /* AOCacheOverPINCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AOCacheOverPINCache.m; sourceTree = "<group>"; };
+		DC2AD3962020832800C9FC61 /* AOCacheOverNSCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AOCacheOverNSCache.m; sourceTree = "<group>"; };
+		DC2AD3972020832800C9FC61 /* AOCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AOCache.m; sourceTree = "<group>"; };
+		DC2AD3982020832800C9FC61 /* AOService+CacheController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "AOService+CacheController.m"; sourceTree = "<group>"; };
+		DC2AD3992020832800C9FC61 /* AOCacheDTO.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AOCacheDTO.m; sourceTree = "<group>"; };
+		DC2AD39A2020832800C9FC61 /* AOCacheHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AOCacheHelper.h; sourceTree = "<group>"; };
+		DC2AD39B2020832800C9FC61 /* AOCacheHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AOCacheHandler.h; sourceTree = "<group>"; };
+		DC2AD39D2020832900C9FC61 /* AORequestMetadata.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AORequestMetadata.m; sourceTree = "<group>"; };
+		DC2AD39E2020832900C9FC61 /* AOPagingMetadata.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AOPagingMetadata.m; sourceTree = "<group>"; };
+		DC2AD39F2020832900C9FC61 /* AOPagingMetadata.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AOPagingMetadata.h; sourceTree = "<group>"; };
+		DC2AD3A02020832900C9FC61 /* AORequestMetadata.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AORequestMetadata.h; sourceTree = "<group>"; };
+		DC2AD3A22020832900C9FC61 /* AccedoOneControl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AccedoOneControl.h; sourceTree = "<group>"; };
+		DC2AD3A32020832900C9FC61 /* AccedoOnePublish.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AccedoOnePublish.m; sourceTree = "<group>"; };
+		DC2AD3A42020832900C9FC61 /* AccedoOneInsight.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AccedoOneInsight.m; sourceTree = "<group>"; };
+		DC2AD3A52020832900C9FC61 /* AccedoOneDetect.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AccedoOneDetect.h; sourceTree = "<group>"; };
+		DC2AD3A62020832900C9FC61 /* AccedoOneUserData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AccedoOneUserData.h; sourceTree = "<group>"; };
+		DC2AD3A72020832900C9FC61 /* AccedoOneControl.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AccedoOneControl.m; sourceTree = "<group>"; };
+		DC2AD3A82020832900C9FC61 /* AccedoOneInsight.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AccedoOneInsight.h; sourceTree = "<group>"; };
+		DC2AD3A92020832900C9FC61 /* AccedoOnePublish.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AccedoOnePublish.h; sourceTree = "<group>"; };
+		DC2AD3AA2020832900C9FC61 /* AccedoOneDetect.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AccedoOneDetect.m; sourceTree = "<group>"; };
+		DC2AD3AB2020832900C9FC61 /* AccedoOneUserData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AccedoOneUserData.m; sourceTree = "<group>"; };
+		DC2AD3AE2020832900C9FC61 /* AOService.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AOService.m; sourceTree = "<group>"; };
+		DC2AD3AF2020832900C9FC61 /* AOServiceComponent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AOServiceComponent.h; sourceTree = "<group>"; };
+		DC2AD3B02020832900C9FC61 /* AOCMSOptionalParams.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AOCMSOptionalParams.h; sourceTree = "<group>"; };
+		DC2AD3B12020832900C9FC61 /* AOService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AOService.h; sourceTree = "<group>"; };
+		DC2AD3B22020832900C9FC61 /* AOCMSOptionalParams.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AOCMSOptionalParams.m; sourceTree = "<group>"; };
+		DC2AD3B32020832900C9FC61 /* AOServiceComponent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AOServiceComponent.m; sourceTree = "<group>"; };
+		DC2AD3B42020832900C9FC61 /* AOObjectParserProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AOObjectParserProtocol.h; sourceTree = "<group>"; };
+		DC2AD3B62020832900C9FC61 /* AOError.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AOError.h; sourceTree = "<group>"; };
+		DC2AD3B72020832900C9FC61 /* AOAsynchBlockOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AOAsynchBlockOperation.h; sourceTree = "<group>"; };
+		DC2AD3B82020832900C9FC61 /* NSString+AO.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+AO.m"; sourceTree = "<group>"; };
+		DC2AD3B92020832900C9FC61 /* AOFileUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AOFileUtils.m; sourceTree = "<group>"; };
+		DC2AD3BA2020832900C9FC61 /* NSArray+AO.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSArray+AO.h"; sourceTree = "<group>"; };
+		DC2AD3BB2020832900C9FC61 /* AOError.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AOError.m; sourceTree = "<group>"; };
+		DC2AD3BC2020832900C9FC61 /* AOAsynchBlockOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AOAsynchBlockOperation.m; sourceTree = "<group>"; };
+		DC2AD3BD2020832900C9FC61 /* NSString+AO.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+AO.h"; sourceTree = "<group>"; };
+		DC2AD3BE2020832900C9FC61 /* NSArray+AO.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSArray+AO.m"; sourceTree = "<group>"; };
+		DC2AD3BF2020832900C9FC61 /* AOFileUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AOFileUtils.h; sourceTree = "<group>"; };
+		DC2AD3EE2020836700C9FC61 /* AccedoOneControlProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AccedoOneControlProtocol.h; sourceTree = "<group>"; };
+		DC2AD3F02020837C00C9FC61 /* AccedoOneDetectProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AccedoOneDetectProtocol.h; sourceTree = "<group>"; };
+		DC2AD3F22020839000C9FC61 /* AccedoOneInsightProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AccedoOneInsightProtocol.h; sourceTree = "<group>"; };
+		DC2AD3F4202083A000C9FC61 /* AccedoOnePublishProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AccedoOnePublishProtocol.h; sourceTree = "<group>"; };
+		DC2AD3F6202083B200C9FC61 /* AccedoOneUserDataProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AccedoOneUserDataProtocol.h; sourceTree = "<group>"; };
+		DC2AD3F8202083C800C9FC61 /* AccedoOneCacheProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AccedoOneCacheProtocol.h; sourceTree = "<group>"; };
 		EFAAAA4FCC20ED0F3B9A9D78 /* AFURLResponseSerialization.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFURLResponseSerialization.m; path = AccedoOneiOS/Libraries/AFNetworking/AFURLResponseSerialization.m; sourceTree = "<group>"; };
 		F14BE38349AE0B319A08F578 /* AFURLRequestSerialization.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFURLRequestSerialization.h; path = AccedoOneiOS/Libraries/AFNetworking/AFURLRequestSerialization.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -260,15 +272,16 @@
 		8CE8C6E91FEC79C20041C284 /* AccedoOneiOS */ = {
 			isa = PBXGroup;
 			children = (
-				8CF755891FED1C7E000D7070 /* API */,
-				8CE8C7571FEC7DA30041C284 /* Utils */,
-				8CE8C7561FEC7D9D0041C284 /* Service */,
-				8CE8C7551FEC7D950041C284 /* Request */,
-				8CE8C7341FEC7D1F0041C284 /* Cache */,
-				8CE8C7311FEC7AD60041C284 /* AccedoOneiOS.pch */,
-				8CE8C6EA1FEC79C20041C284 /* AccedoOneiOS.h */,
+				DC2AD3A12020832900C9FC61 /* API */,
+				DC2AD38A2020832800C9FC61 /* Cache */,
+				DC2AD3AC2020832900C9FC61 /* Protocols */,
+				DC2AD39C2020832900C9FC61 /* Request */,
+				DC2AD3AD2020832900C9FC61 /* Service */,
+				DC2AD3B52020832900C9FC61 /* Utils */,
 				8CE8C7271FEC7A4D0041C284 /* AccedoOne.h */,
 				8CE8C7281FEC7A4D0041C284 /* AccedoOne.m */,
+				8CE8C6EA1FEC79C20041C284 /* AccedoOneiOS.h */,
+				8CE8C7311FEC7AD60041C284 /* AccedoOneiOS.pch */,
 				8CE8C6EB1FEC79C20041C284 /* Info.plist */,
 			);
 			path = AccedoOneiOS;
@@ -283,101 +296,120 @@
 			path = AccedoOneiOSTests;
 			sourceTree = "<group>";
 		};
-		8CE8C7341FEC7D1F0041C284 /* Cache */ = {
+		DC2AD38A2020832800C9FC61 /* Cache */ = {
 			isa = PBXGroup;
 			children = (
-				8CE8C7431FEC7D3F0041C284 /* Providers */,
-				8CE8C7351FEC7D340041C284 /* AOCacheDTO.h */,
-				8CE8C7361FEC7D340041C284 /* AOCacheDTO.m */,
-				8CE8C73B1FEC7D340041C284 /* AOCacheHandler.h */,
-				8CE8C73A1FEC7D340041C284 /* AOCacheHelper.h */,
-				8CE8C7371FEC7D340041C284 /* AOCacheHelper.m */,
-				8CE8C7381FEC7D340041C284 /* AOService+CacheController.h */,
-				8CE8C7391FEC7D340041C284 /* AOService+CacheController.m */,
+				DC2AD38E2020832800C9FC61 /* Providers */,
+				DC2AD39B2020832800C9FC61 /* AOCacheHandler.h */,
+				DC2AD38B2020832800C9FC61 /* AOCacheDTO.h */,
+				DC2AD3992020832800C9FC61 /* AOCacheDTO.m */,
+				DC2AD38C2020832800C9FC61 /* AOService+CacheController.h */,
+				DC2AD3982020832800C9FC61 /* AOService+CacheController.m */,
+				DC2AD38D2020832800C9FC61 /* AOCacheHelper.m */,
+				DC2AD39A2020832800C9FC61 /* AOCacheHelper.h */,
 			);
-			path = Cache;
+			name = Cache;
+			path = ../../Common/Cache;
 			sourceTree = "<group>";
 		};
-		8CE8C7431FEC7D3F0041C284 /* Providers */ = {
+		DC2AD38E2020832800C9FC61 /* Providers */ = {
 			isa = PBXGroup;
 			children = (
-				8CE8C7501FEC7D5E0041C284 /* Model */,
-				8CE8C7491FEC7D5B0041C284 /* AOCache.h */,
-				8CE8C7441FEC7D5A0041C284 /* AOCache.m */,
-				8CE8C7481FEC7D5B0041C284 /* AOCacheOverNSCache.h */,
-				8CE8C7451FEC7D5A0041C284 /* AOCacheOverNSCache.m */,
-				8CE8C7461FEC7D5A0041C284 /* AOCacheOverPINCache.h */,
-				8CE8C7471FEC7D5A0041C284 /* AOCacheOverPINCache.m */,
+				DC2AD3922020832800C9FC61 /* Model */,
+				DC2AD38F2020832800C9FC61 /* AOCache.h */,
+				DC2AD3972020832800C9FC61 /* AOCache.m */,
+				DC2AD3902020832800C9FC61 /* AOCacheOverNSCache.h */,
+				DC2AD3962020832800C9FC61 /* AOCacheOverNSCache.m */,
+				DC2AD3912020832800C9FC61 /* AOCacheOverPINCache.h */,
+				DC2AD3952020832800C9FC61 /* AOCacheOverPINCache.m */,
 			);
 			path = Providers;
 			sourceTree = "<group>";
 		};
-		8CE8C7501FEC7D5E0041C284 /* Model */ = {
+		DC2AD3922020832800C9FC61 /* Model */ = {
 			isa = PBXGroup;
 			children = (
-				8CE8C7511FEC7D730041C284 /* AOCacheAtom.h */,
-				8CE8C7521FEC7D730041C284 /* AOCacheAtom.m */,
+				DC2AD3932020832800C9FC61 /* AOCacheAtom.m */,
+				DC2AD3942020832800C9FC61 /* AOCacheAtom.h */,
 			);
 			path = Model;
 			sourceTree = "<group>";
 		};
-		8CE8C7551FEC7D950041C284 /* Request */ = {
+		DC2AD39C2020832900C9FC61 /* Request */ = {
 			isa = PBXGroup;
 			children = (
-				8CE8C7591FEC7DB50041C284 /* AOPagingMetadata.h */,
-				8CE8C7581FEC7DB50041C284 /* AOPagingMetadata.m */,
-				8CE8C75A1FEC7DB50041C284 /* AORequestMetadata.h */,
-				8CE8C75B1FEC7DB50041C284 /* AORequestMetadata.m */,
+				DC2AD3A02020832900C9FC61 /* AORequestMetadata.h */,
+				DC2AD39D2020832900C9FC61 /* AORequestMetadata.m */,
+				DC2AD39F2020832900C9FC61 /* AOPagingMetadata.h */,
+				DC2AD39E2020832900C9FC61 /* AOPagingMetadata.m */,
 			);
-			path = Request;
+			name = Request;
+			path = ../../Common/Request;
 			sourceTree = "<group>";
 		};
-		8CE8C7561FEC7D9D0041C284 /* Service */ = {
+		DC2AD3A12020832900C9FC61 /* API */ = {
 			isa = PBXGroup;
 			children = (
-				8CE8C7651FEC7DC80041C284 /* AOCMSOptionalParams.h */,
-				8CE8C7601FEC7DC80041C284 /* AOCMSOptionalParams.m */,
-				8CE8C7631FEC7DC80041C284 /* AOObjectParserProtocol.h */,
-				8CE8C7621FEC7DC80041C284 /* AOService.h */,
-				8CE8C7641FEC7DC80041C284 /* AOService.m */,
-				8CE8C7611FEC7DC80041C284 /* AOServiceComponent.h */,
-				8CE8C7661FEC7DC80041C284 /* AOServiceComponent.m */,
+				DC2AD3A22020832900C9FC61 /* AccedoOneControl.h */,
+				DC2AD3A72020832900C9FC61 /* AccedoOneControl.m */,
+				DC2AD3A52020832900C9FC61 /* AccedoOneDetect.h */,
+				DC2AD3AA2020832900C9FC61 /* AccedoOneDetect.m */,
+				DC2AD3A82020832900C9FC61 /* AccedoOneInsight.h */,
+				DC2AD3A42020832900C9FC61 /* AccedoOneInsight.m */,
+				DC2AD3A92020832900C9FC61 /* AccedoOnePublish.h */,
+				DC2AD3A32020832900C9FC61 /* AccedoOnePublish.m */,
+				DC2AD3A62020832900C9FC61 /* AccedoOneUserData.h */,
+				DC2AD3AB2020832900C9FC61 /* AccedoOneUserData.m */,
 			);
-			path = Service;
+			name = API;
+			path = ../../Common/API;
 			sourceTree = "<group>";
 		};
-		8CE8C7571FEC7DA30041C284 /* Utils */ = {
+		DC2AD3AC2020832900C9FC61 /* Protocols */ = {
 			isa = PBXGroup;
 			children = (
-				8CE8C7751FEC7DD90041C284 /* AOAsynchBlockOperation.h */,
-				8CE8C76E1FEC7DD90041C284 /* AOAsynchBlockOperation.m */,
-				8CE8C7711FEC7DD90041C284 /* AOError.h */,
-				8CE8C76F1FEC7DD90041C284 /* AOError.m */,
-				8CE8C7771FEC7DD90041C284 /* AOFileUtils.h */,
-				8CE8C7701FEC7DD90041C284 /* AOFileUtils.m */,
-				8CE8C7731FEC7DD90041C284 /* NSArray+AO.h */,
-				8CE8C7741FEC7DD90041C284 /* NSArray+AO.m */,
-				8CE8C7761FEC7DD90041C284 /* NSString+AO.h */,
-				8CE8C7721FEC7DD90041C284 /* NSString+AO.m */,
+				DC2AD3EE2020836700C9FC61 /* AccedoOneControlProtocol.h */,
+				DC2AD3F02020837C00C9FC61 /* AccedoOneDetectProtocol.h */,
+				DC2AD3F22020839000C9FC61 /* AccedoOneInsightProtocol.h */,
+				DC2AD3F4202083A000C9FC61 /* AccedoOnePublishProtocol.h */,
+				DC2AD3F6202083B200C9FC61 /* AccedoOneUserDataProtocol.h */,
+				DC2AD3F8202083C800C9FC61 /* AccedoOneCacheProtocol.h */,
 			);
-			path = Utils;
+			name = Protocols;
+			path = ../../Common/Protocols;
 			sourceTree = "<group>";
 		};
-		8CF755891FED1C7E000D7070 /* API */ = {
+		DC2AD3AD2020832900C9FC61 /* Service */ = {
 			isa = PBXGroup;
 			children = (
-				8CF755A31FED3B1C000D7070 /* AccedoOneControl.h */,
-				8CF755A51FED3B1C000D7070 /* AccedoOneControl.m */,
-				8CF755A21FED3B1C000D7070 /* AccedoOneDetect.h */,
-				8CF755A11FED3B1C000D7070 /* AccedoOneDetect.m */,
-				8CF7559E1FED3B1C000D7070 /* AccedoOneInsight.h */,
-				8CF755A01FED3B1C000D7070 /* AccedoOneInsight.m */,
-				8CF755A41FED3B1C000D7070 /* AccedoOnePublish.h */,
-				8CF755A71FED3B1C000D7070 /* AccedoOnePublish.m */,
-				8CF7559F1FED3B1C000D7070 /* AccedoOneUserData.h */,
-				8CF755A61FED3B1C000D7070 /* AccedoOneUserData.m */,
+				DC2AD3B12020832900C9FC61 /* AOService.h */,
+				DC2AD3AE2020832900C9FC61 /* AOService.m */,
+				DC2AD3AF2020832900C9FC61 /* AOServiceComponent.h */,
+				DC2AD3B32020832900C9FC61 /* AOServiceComponent.m */,
+				DC2AD3B02020832900C9FC61 /* AOCMSOptionalParams.h */,
+				DC2AD3B22020832900C9FC61 /* AOCMSOptionalParams.m */,
+				DC2AD3B42020832900C9FC61 /* AOObjectParserProtocol.h */,
 			);
-			path = API;
+			name = Service;
+			path = ../../Common/Service;
+			sourceTree = "<group>";
+		};
+		DC2AD3B52020832900C9FC61 /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				DC2AD3B62020832900C9FC61 /* AOError.h */,
+				DC2AD3BB2020832900C9FC61 /* AOError.m */,
+				DC2AD3B82020832900C9FC61 /* NSString+AO.m */,
+				DC2AD3BD2020832900C9FC61 /* NSString+AO.h */,
+				DC2AD3BA2020832900C9FC61 /* NSArray+AO.h */,
+				DC2AD3BE2020832900C9FC61 /* NSArray+AO.m */,
+				DC2AD3B72020832900C9FC61 /* AOAsynchBlockOperation.h */,
+				DC2AD3BC2020832900C9FC61 /* AOAsynchBlockOperation.m */,
+				DC2AD3BF2020832900C9FC61 /* AOFileUtils.h */,
+				DC2AD3B92020832900C9FC61 /* AOFileUtils.m */,
+			);
+			name = Utils;
+			path = ../../Common/Utils;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -387,33 +419,39 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8CE8C77B1FEC7DD90041C284 /* AOError.h in Headers */,
-				8CE8C7691FEC7DC80041C284 /* AOService.h in Headers */,
-				8CE8C75E1FEC7DB50041C284 /* AORequestMetadata.h in Headers */,
+				DC2AD3F5202083A000C9FC61 /* AccedoOnePublishProtocol.h in Headers */,
+				DC2AD3F12020837C00C9FC61 /* AccedoOneDetectProtocol.h in Headers */,
+				DC2AD3E52020832900C9FC61 /* AOAsynchBlockOperation.h in Headers */,
 				8CE8C72D1FEC7A4D0041C284 /* AccedoOne.h in Headers */,
-				8CE8C7681FEC7DC80041C284 /* AOServiceComponent.h in Headers */,
-				8CE8C75D1FEC7DB50041C284 /* AOPagingMetadata.h in Headers */,
-				8CF755AE1FED3B1C000D7070 /* AccedoOnePublish.h in Headers */,
-				8CF755A81FED3B1C000D7070 /* AccedoOneInsight.h in Headers */,
-				8CF755AC1FED3B1C000D7070 /* AccedoOneDetect.h in Headers */,
-				8CF755A91FED3B1C000D7070 /* AccedoOneUserData.h in Headers */,
-				8CF755AD1FED3B1C000D7070 /* AccedoOneControl.h in Headers */,
-				8CE8C7421FEC7D340041C284 /* AOCacheHandler.h in Headers */,
-				8CE8C76A1FEC7DC80041C284 /* AOObjectParserProtocol.h in Headers */,
-				8CE8C76C1FEC7DC80041C284 /* AOCMSOptionalParams.h in Headers */,
-				8CE8C74F1FEC7D5B0041C284 /* AOCache.h in Headers */,
-				8CE8C7531FEC7D730041C284 /* AOCacheAtom.h in Headers */,
-				8CE8C7811FEC7DD90041C284 /* AOFileUtils.h in Headers */,
-				8CE8C73C1FEC7D340041C284 /* AOCacheDTO.h in Headers */,
+				DC2AD3D62020832900C9FC61 /* AccedoOneDetect.h in Headers */,
+				DC2AD3C32020832900C9FC61 /* AOCache.h in Headers */,
+				DC2AD3D72020832900C9FC61 /* AccedoOneUserData.h in Headers */,
+				DC2AD3DA2020832900C9FC61 /* AccedoOnePublish.h in Headers */,
+				DC2AD3C02020832900C9FC61 /* AOCacheDTO.h in Headers */,
+				DC2AD3E02020832900C9FC61 /* AOService.h in Headers */,
+				DC2AD3D92020832900C9FC61 /* AccedoOneInsight.h in Headers */,
 				8CE8C7321FEC7AD60041C284 /* AccedoOneiOS.pch in Headers */,
-				8CE8C7411FEC7D340041C284 /* AOCacheHelper.h in Headers */,
-				8CE8C7801FEC7DD90041C284 /* NSString+AO.h in Headers */,
 				8CE8C6F81FEC79C20041C284 /* AccedoOneiOS.h in Headers */,
-				8CE8C77D1FEC7DD90041C284 /* NSArray+AO.h in Headers */,
-				8CE8C74E1FEC7D5B0041C284 /* AOCacheOverNSCache.h in Headers */,
-				8CE8C73F1FEC7D340041C284 /* AOService+CacheController.h in Headers */,
-				8CE8C77F1FEC7DD90041C284 /* AOAsynchBlockOperation.h in Headers */,
-				8CE8C74C1FEC7D5B0041C284 /* AOCacheOverPINCache.h in Headers */,
+				DC2AD3C42020832900C9FC61 /* AOCacheOverNSCache.h in Headers */,
+				DC2AD3E42020832900C9FC61 /* AOError.h in Headers */,
+				DC2AD3C72020832900C9FC61 /* AOCacheAtom.h in Headers */,
+				DC2AD3D12020832900C9FC61 /* AOPagingMetadata.h in Headers */,
+				DC2AD3D32020832900C9FC61 /* AccedoOneControl.h in Headers */,
+				DC2AD3ED2020832900C9FC61 /* AOFileUtils.h in Headers */,
+				DC2AD3EB2020832900C9FC61 /* NSString+AO.h in Headers */,
+				DC2AD3CE2020832900C9FC61 /* AOCacheHandler.h in Headers */,
+				DC2AD3C52020832900C9FC61 /* AOCacheOverPINCache.h in Headers */,
+				DC2AD3D22020832900C9FC61 /* AORequestMetadata.h in Headers */,
+				DC2AD3DF2020832900C9FC61 /* AOCMSOptionalParams.h in Headers */,
+				DC2AD3DE2020832900C9FC61 /* AOServiceComponent.h in Headers */,
+				DC2AD3C12020832900C9FC61 /* AOService+CacheController.h in Headers */,
+				DC2AD3EF2020836700C9FC61 /* AccedoOneControlProtocol.h in Headers */,
+				DC2AD3E32020832900C9FC61 /* AOObjectParserProtocol.h in Headers */,
+				DC2AD3F9202083C800C9FC61 /* AccedoOneCacheProtocol.h in Headers */,
+				DC2AD3F32020839000C9FC61 /* AccedoOneInsightProtocol.h in Headers */,
+				DC2AD3F7202083B200C9FC61 /* AccedoOneUserDataProtocol.h in Headers */,
+				DC2AD3E82020832900C9FC61 /* NSArray+AO.h in Headers */,
+				DC2AD3CD2020832900C9FC61 /* AOCacheHelper.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -536,38 +574,38 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8CE8C73D1FEC7D340041C284 /* AOCacheDTO.m in Sources */,
-				8CE8C7671FEC7DC80041C284 /* AOCMSOptionalParams.m in Sources */,
 				8CE8C72E1FEC7A4D0041C284 /* AccedoOne.m in Sources */,
-				8CE8C76B1FEC7DC80041C284 /* AOService.m in Sources */,
+				DC2AD3E22020832900C9FC61 /* AOServiceComponent.m in Sources */,
+				DC2AD3EC2020832900C9FC61 /* NSArray+AO.m in Sources */,
+				DC2AD3CA2020832900C9FC61 /* AOCache.m in Sources */,
+				DC2AD3CF2020832900C9FC61 /* AORequestMetadata.m in Sources */,
+				DC2AD3D82020832900C9FC61 /* AccedoOneControl.m in Sources */,
+				DC2AD3EA2020832900C9FC61 /* AOAsynchBlockOperation.m in Sources */,
 				72709C9D3E15D44867BB0BD6 /* AFURLResponseSerialization.m in Sources */,
-				8CF755B11FED3B1C000D7070 /* AccedoOnePublish.m in Sources */,
-				8CE8C77C1FEC7DD90041C284 /* NSString+AO.m in Sources */,
-				8CE8C74B1FEC7D5B0041C284 /* AOCacheOverNSCache.m in Sources */,
+				DC2AD3C92020832900C9FC61 /* AOCacheOverNSCache.m in Sources */,
 				0BCFD7290A10C77CFEC79F52 /* AFHTTPSessionManager.m in Sources */,
-				8CF755AB1FED3B1C000D7070 /* AccedoOneDetect.m in Sources */,
+				DC2AD3C82020832900C9FC61 /* AOCacheOverPINCache.m in Sources */,
 				D7EE5BC22059A408CFBD01A4 /* AFURLSessionManager.m in Sources */,
-				8CE8C7541FEC7D730041C284 /* AOCacheAtom.m in Sources */,
+				DC2AD3E92020832900C9FC61 /* AOError.m in Sources */,
+				DC2AD3D02020832900C9FC61 /* AOPagingMetadata.m in Sources */,
+				DC2AD3E62020832900C9FC61 /* NSString+AO.m in Sources */,
+				DC2AD3CC2020832900C9FC61 /* AOCacheDTO.m in Sources */,
 				A9AE262560AD26F480AE3463 /* AFURLRequestSerialization.m in Sources */,
-				8CE8C75C1FEC7DB50041C284 /* AOPagingMetadata.m in Sources */,
-				8CF755AF1FED3B1C000D7070 /* AccedoOneControl.m in Sources */,
-				8CF755AA1FED3B1C000D7070 /* AccedoOneInsight.m in Sources */,
-				8CE8C76D1FEC7DC80041C284 /* AOServiceComponent.m in Sources */,
-				8CE8C7781FEC7DD90041C284 /* AOAsynchBlockOperation.m in Sources */,
-				8CE8C74A1FEC7D5B0041C284 /* AOCache.m in Sources */,
-				8CE8C73E1FEC7D340041C284 /* AOCacheHelper.m in Sources */,
 				7C221246A78D16B432F728B3 /* AFNetworkReachabilityManager.m in Sources */,
+				DC2AD3D52020832900C9FC61 /* AccedoOneInsight.m in Sources */,
 				99C686DC93237DA650EEC259 /* AFSecurityPolicy.m in Sources */,
-				8CE8C74D1FEC7D5B0041C284 /* AOCacheOverPINCache.m in Sources */,
+				DC2AD3DB2020832900C9FC61 /* AccedoOneDetect.m in Sources */,
+				DC2AD3DC2020832900C9FC61 /* AccedoOneUserData.m in Sources */,
+				DC2AD3D42020832900C9FC61 /* AccedoOnePublish.m in Sources */,
+				DC2AD3E72020832900C9FC61 /* AOFileUtils.m in Sources */,
+				DC2AD3CB2020832900C9FC61 /* AOService+CacheController.m in Sources */,
+				DC2AD3E12020832900C9FC61 /* AOCMSOptionalParams.m in Sources */,
+				DC2AD3DD2020832900C9FC61 /* AOService.m in Sources */,
 				B5191C5DFD056582A4B66F3F /* PINCache.m in Sources */,
-				8CE8C77A1FEC7DD90041C284 /* AOFileUtils.m in Sources */,
 				F98676B37884377F05E4376D /* PINMemoryCache.m in Sources */,
-				8CE8C77E1FEC7DD90041C284 /* NSArray+AO.m in Sources */,
+				DC2AD3C62020832900C9FC61 /* AOCacheAtom.m in Sources */,
+				DC2AD3C22020832900C9FC61 /* AOCacheHelper.m in Sources */,
 				E7D5F4EB2FCFE7F1DFCF7100 /* PINDiskCache.m in Sources */,
-				8CF755B01FED3B1C000D7070 /* AccedoOneUserData.m in Sources */,
-				8CE8C75F1FEC7DB50041C284 /* AORequestMetadata.m in Sources */,
-				8CE8C7791FEC7DD90041C284 /* AOError.m in Sources */,
-				8CE8C7401FEC7D340041C284 /* AOService+CacheController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AccedoOneiOS/AccedoOneiOS/Info.plist
+++ b/AccedoOneiOS/AccedoOneiOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.0</string>
+	<string>1.0.2</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/AccedoOnetvOS/AccedoOnetvOS.xcodeproj/project.pbxproj
+++ b/AccedoOnetvOS/AccedoOnetvOS.xcodeproj/project.pbxproj
@@ -31,55 +31,61 @@
 		8CE8C7851FEC7E6B0041C284 /* AccedoOne.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CE8C7821FEC7E6A0041C284 /* AccedoOne.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8CE8C7861FEC7E6B0041C284 /* AccedoOne.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CE8C7831FEC7E6A0041C284 /* AccedoOne.m */; };
 		8CE8C78F1FEC7ECA0041C284 /* AccedoOnetvOS.pch in Headers */ = {isa = PBXBuildFile; fileRef = 8CE8C78E1FEC7ECA0041C284 /* AccedoOnetvOS.pch */; };
-		8CE8C7971FEC7EE20041C284 /* AOCMSOptionalParams.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CE8C7901FEC7EE20041C284 /* AOCMSOptionalParams.m */; };
-		8CE8C7981FEC7EE20041C284 /* AOServiceComponent.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CE8C7911FEC7EE20041C284 /* AOServiceComponent.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8CE8C7991FEC7EE20041C284 /* AOService.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CE8C7921FEC7EE20041C284 /* AOService.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8CE8C79A1FEC7EE20041C284 /* AOObjectParserProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CE8C7931FEC7EE20041C284 /* AOObjectParserProtocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8CE8C79B1FEC7EE20041C284 /* AOService.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CE8C7941FEC7EE20041C284 /* AOService.m */; };
-		8CE8C79C1FEC7EE20041C284 /* AOCMSOptionalParams.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CE8C7951FEC7EE20041C284 /* AOCMSOptionalParams.h */; };
-		8CE8C79D1FEC7EE20041C284 /* AOServiceComponent.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CE8C7961FEC7EE20041C284 /* AOServiceComponent.m */; };
-		8CE8C7A21FEC7EF10041C284 /* AOPagingMetadata.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CE8C79E1FEC7EF10041C284 /* AOPagingMetadata.m */; };
-		8CE8C7A31FEC7EF10041C284 /* AOPagingMetadata.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CE8C79F1FEC7EF10041C284 /* AOPagingMetadata.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8CE8C7A41FEC7EF10041C284 /* AORequestMetadata.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CE8C7A01FEC7EF10041C284 /* AORequestMetadata.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8CE8C7A51FEC7EF10041C284 /* AORequestMetadata.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CE8C7A11FEC7EF10041C284 /* AORequestMetadata.m */; };
-		8CE8C7B01FEC7EFF0041C284 /* AOAsynchBlockOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CE8C7A61FEC7EFF0041C284 /* AOAsynchBlockOperation.m */; };
-		8CE8C7B11FEC7EFF0041C284 /* AOError.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CE8C7A71FEC7EFF0041C284 /* AOError.m */; };
-		8CE8C7B21FEC7EFF0041C284 /* AOFileUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CE8C7A81FEC7EFF0041C284 /* AOFileUtils.m */; };
-		8CE8C7B31FEC7EFF0041C284 /* AOError.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CE8C7A91FEC7EFF0041C284 /* AOError.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8CE8C7B41FEC7EFF0041C284 /* NSString+AO.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CE8C7AA1FEC7EFF0041C284 /* NSString+AO.m */; };
-		8CE8C7B51FEC7EFF0041C284 /* NSArray+AO.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CE8C7AB1FEC7EFF0041C284 /* NSArray+AO.h */; };
-		8CE8C7B61FEC7EFF0041C284 /* NSArray+AO.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CE8C7AC1FEC7EFF0041C284 /* NSArray+AO.m */; };
-		8CE8C7B71FEC7EFF0041C284 /* AOAsynchBlockOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CE8C7AD1FEC7EFF0041C284 /* AOAsynchBlockOperation.h */; };
-		8CE8C7B81FEC7EFF0041C284 /* NSString+AO.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CE8C7AE1FEC7EFF0041C284 /* NSString+AO.h */; };
-		8CE8C7B91FEC7EFF0041C284 /* AOFileUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CE8C7AF1FEC7EFF0041C284 /* AOFileUtils.h */; };
-		8CE8C7C11FEC7F180041C284 /* AOCacheDTO.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CE8C7BA1FEC7F180041C284 /* AOCacheDTO.h */; };
-		8CE8C7C21FEC7F180041C284 /* AOCacheDTO.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CE8C7BB1FEC7F180041C284 /* AOCacheDTO.m */; };
-		8CE8C7C31FEC7F180041C284 /* AOCacheHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CE8C7BC1FEC7F180041C284 /* AOCacheHelper.m */; };
-		8CE8C7C41FEC7F180041C284 /* AOService+CacheController.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CE8C7BD1FEC7F180041C284 /* AOService+CacheController.h */; };
-		8CE8C7C51FEC7F180041C284 /* AOService+CacheController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CE8C7BE1FEC7F180041C284 /* AOService+CacheController.m */; };
-		8CE8C7C61FEC7F180041C284 /* AOCacheHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CE8C7BF1FEC7F180041C284 /* AOCacheHelper.h */; };
-		8CE8C7C71FEC7F180041C284 /* AOCacheHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CE8C7C01FEC7F180041C284 /* AOCacheHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8CE8C7CF1FEC7F2B0041C284 /* AOCacheOverPINCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CE8C7C81FEC7F2B0041C284 /* AOCacheOverPINCache.m */; };
-		8CE8C7D11FEC7F2B0041C284 /* AOCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CE8C7CA1FEC7F2B0041C284 /* AOCache.h */; };
-		8CE8C7D21FEC7F2B0041C284 /* AOCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CE8C7CB1FEC7F2B0041C284 /* AOCache.m */; };
-		8CE8C7D31FEC7F2B0041C284 /* AOCacheOverPINCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CE8C7CC1FEC7F2B0041C284 /* AOCacheOverPINCache.h */; };
-		8CE8C7D41FEC7F2B0041C284 /* AOCacheOverNSCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CE8C7CD1FEC7F2B0041C284 /* AOCacheOverNSCache.h */; };
-		8CE8C7D51FEC7F2B0041C284 /* AOCacheOverNSCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CE8C7CE1FEC7F2B0041C284 /* AOCacheOverNSCache.m */; };
-		8CE8C7D81FEC7F3E0041C284 /* AOCacheAtom.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CE8C7D61FEC7F3E0041C284 /* AOCacheAtom.h */; };
-		8CE8C7D91FEC7F3E0041C284 /* AOCacheAtom.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CE8C7D71FEC7F3E0041C284 /* AOCacheAtom.m */; };
-		8CF755BD1FED3B50000D7070 /* AccedoOneInsight.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CF755B31FED3B50000D7070 /* AccedoOneInsight.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8CF755BE1FED3B50000D7070 /* AccedoOneUserData.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CF755B41FED3B50000D7070 /* AccedoOneUserData.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8CF755BF1FED3B50000D7070 /* AccedoOneInsight.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CF755B51FED3B50000D7070 /* AccedoOneInsight.m */; };
-		8CF755C01FED3B50000D7070 /* AccedoOneDetect.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CF755B61FED3B50000D7070 /* AccedoOneDetect.m */; };
-		8CF755C11FED3B50000D7070 /* AccedoOneDetect.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CF755B71FED3B50000D7070 /* AccedoOneDetect.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8CF755C21FED3B50000D7070 /* AccedoOneControl.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CF755B81FED3B50000D7070 /* AccedoOneControl.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8CF755C31FED3B50000D7070 /* AccedoOnePublish.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CF755B91FED3B50000D7070 /* AccedoOnePublish.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8CF755C41FED3B50000D7070 /* AccedoOneControl.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CF755BA1FED3B50000D7070 /* AccedoOneControl.m */; };
-		8CF755C51FED3B50000D7070 /* AccedoOneUserData.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CF755BB1FED3B50000D7070 /* AccedoOneUserData.m */; };
-		8CF755C61FED3B50000D7070 /* AccedoOnePublish.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CF755BC1FED3B50000D7070 /* AccedoOnePublish.m */; };
 		97015C22C3CAD8985863D8B9 /* AFURLRequestSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = D91BE977DBD7D1FE179AD89F /* AFURLRequestSerialization.m */; };
 		9DD6D05F8FB8AD92B755E3F4 /* AFNetworkReachabilityManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B40C21E45A2949895407CDB /* AFNetworkReachabilityManager.m */; };
 		B5BF2C33B9183F5B27F6FE44 /* AFURLSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = EA39A3BDDCE8DEAE1134E26A /* AFURLSessionManager.m */; };
+		DC2AD4372020A4E100C9FC61 /* AOCacheDTO.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD3FC2020A4E000C9FC61 /* AOCacheDTO.h */; };
+		DC2AD4382020A4E100C9FC61 /* AOService+CacheController.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD3FD2020A4E000C9FC61 /* AOService+CacheController.h */; };
+		DC2AD4392020A4E100C9FC61 /* AOCacheHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = DC2AD3FE2020A4E000C9FC61 /* AOCacheHelper.m */; };
+		DC2AD43A2020A4E100C9FC61 /* AOCache.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD4002020A4E000C9FC61 /* AOCache.h */; };
+		DC2AD43B2020A4E100C9FC61 /* AOCacheOverNSCache.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD4012020A4E000C9FC61 /* AOCacheOverNSCache.h */; };
+		DC2AD43C2020A4E100C9FC61 /* AOCacheOverPINCache.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD4022020A4E000C9FC61 /* AOCacheOverPINCache.h */; };
+		DC2AD43D2020A4E100C9FC61 /* AOCacheAtom.m in Sources */ = {isa = PBXBuildFile; fileRef = DC2AD4042020A4E000C9FC61 /* AOCacheAtom.m */; };
+		DC2AD43E2020A4E100C9FC61 /* AOCacheAtom.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD4052020A4E000C9FC61 /* AOCacheAtom.h */; };
+		DC2AD43F2020A4E100C9FC61 /* AOCacheOverPINCache.m in Sources */ = {isa = PBXBuildFile; fileRef = DC2AD4062020A4E000C9FC61 /* AOCacheOverPINCache.m */; };
+		DC2AD4402020A4E100C9FC61 /* AOCacheOverNSCache.m in Sources */ = {isa = PBXBuildFile; fileRef = DC2AD4072020A4E000C9FC61 /* AOCacheOverNSCache.m */; };
+		DC2AD4412020A4E100C9FC61 /* AOCache.m in Sources */ = {isa = PBXBuildFile; fileRef = DC2AD4082020A4E000C9FC61 /* AOCache.m */; };
+		DC2AD4422020A4E100C9FC61 /* AOService+CacheController.m in Sources */ = {isa = PBXBuildFile; fileRef = DC2AD4092020A4E000C9FC61 /* AOService+CacheController.m */; };
+		DC2AD4432020A4E100C9FC61 /* AOCacheDTO.m in Sources */ = {isa = PBXBuildFile; fileRef = DC2AD40A2020A4E000C9FC61 /* AOCacheDTO.m */; };
+		DC2AD4442020A4E100C9FC61 /* AOCacheHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD40B2020A4E000C9FC61 /* AOCacheHelper.h */; };
+		DC2AD4452020A4E100C9FC61 /* AOCacheHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD40C2020A4E000C9FC61 /* AOCacheHandler.h */; };
+		DC2AD4462020A4E100C9FC61 /* AORequestMetadata.m in Sources */ = {isa = PBXBuildFile; fileRef = DC2AD40E2020A4E000C9FC61 /* AORequestMetadata.m */; };
+		DC2AD4472020A4E100C9FC61 /* AOPagingMetadata.m in Sources */ = {isa = PBXBuildFile; fileRef = DC2AD40F2020A4E000C9FC61 /* AOPagingMetadata.m */; };
+		DC2AD4482020A4E100C9FC61 /* AOPagingMetadata.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD4102020A4E000C9FC61 /* AOPagingMetadata.h */; };
+		DC2AD4492020A4E100C9FC61 /* AORequestMetadata.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD4112020A4E000C9FC61 /* AORequestMetadata.h */; };
+		DC2AD44A2020A4E100C9FC61 /* AccedoOneControl.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD4132020A4E100C9FC61 /* AccedoOneControl.h */; };
+		DC2AD44B2020A4E100C9FC61 /* AccedoOnePublish.m in Sources */ = {isa = PBXBuildFile; fileRef = DC2AD4142020A4E100C9FC61 /* AccedoOnePublish.m */; };
+		DC2AD44C2020A4E100C9FC61 /* AccedoOneInsight.m in Sources */ = {isa = PBXBuildFile; fileRef = DC2AD4152020A4E100C9FC61 /* AccedoOneInsight.m */; };
+		DC2AD44D2020A4E100C9FC61 /* AccedoOneDetect.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD4162020A4E100C9FC61 /* AccedoOneDetect.h */; };
+		DC2AD44E2020A4E100C9FC61 /* AccedoOneUserData.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD4172020A4E100C9FC61 /* AccedoOneUserData.h */; };
+		DC2AD44F2020A4E100C9FC61 /* AccedoOneControl.m in Sources */ = {isa = PBXBuildFile; fileRef = DC2AD4182020A4E100C9FC61 /* AccedoOneControl.m */; };
+		DC2AD4502020A4E100C9FC61 /* AccedoOneInsight.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD4192020A4E100C9FC61 /* AccedoOneInsight.h */; };
+		DC2AD4512020A4E100C9FC61 /* AccedoOnePublish.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD41A2020A4E100C9FC61 /* AccedoOnePublish.h */; };
+		DC2AD4522020A4E100C9FC61 /* AccedoOneDetect.m in Sources */ = {isa = PBXBuildFile; fileRef = DC2AD41B2020A4E100C9FC61 /* AccedoOneDetect.m */; };
+		DC2AD4532020A4E100C9FC61 /* AccedoOneUserData.m in Sources */ = {isa = PBXBuildFile; fileRef = DC2AD41C2020A4E100C9FC61 /* AccedoOneUserData.m */; };
+		DC2AD4542020A4E100C9FC61 /* AccedoOneInsightProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD41E2020A4E100C9FC61 /* AccedoOneInsightProtocol.h */; };
+		DC2AD4552020A4E100C9FC61 /* AccedoOneDetectProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD41F2020A4E100C9FC61 /* AccedoOneDetectProtocol.h */; };
+		DC2AD4562020A4E100C9FC61 /* AccedoOneUserDataProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD4202020A4E100C9FC61 /* AccedoOneUserDataProtocol.h */; };
+		DC2AD4572020A4E100C9FC61 /* AccedoOnePublishProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD4212020A4E100C9FC61 /* AccedoOnePublishProtocol.h */; };
+		DC2AD4582020A4E100C9FC61 /* AccedoOneCacheProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD4222020A4E100C9FC61 /* AccedoOneCacheProtocol.h */; };
+		DC2AD4592020A4E100C9FC61 /* AccedoOneControlProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD4232020A4E100C9FC61 /* AccedoOneControlProtocol.h */; };
+		DC2AD45A2020A4E100C9FC61 /* AOService.m in Sources */ = {isa = PBXBuildFile; fileRef = DC2AD4252020A4E100C9FC61 /* AOService.m */; };
+		DC2AD45B2020A4E100C9FC61 /* AOServiceComponent.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD4262020A4E100C9FC61 /* AOServiceComponent.h */; };
+		DC2AD45C2020A4E100C9FC61 /* AOCMSOptionalParams.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD4272020A4E100C9FC61 /* AOCMSOptionalParams.h */; };
+		DC2AD45D2020A4E100C9FC61 /* AOService.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD4282020A4E100C9FC61 /* AOService.h */; };
+		DC2AD45E2020A4E100C9FC61 /* AOCMSOptionalParams.m in Sources */ = {isa = PBXBuildFile; fileRef = DC2AD4292020A4E100C9FC61 /* AOCMSOptionalParams.m */; };
+		DC2AD45F2020A4E100C9FC61 /* AOServiceComponent.m in Sources */ = {isa = PBXBuildFile; fileRef = DC2AD42A2020A4E100C9FC61 /* AOServiceComponent.m */; };
+		DC2AD4602020A4E100C9FC61 /* AOObjectParserProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD42B2020A4E100C9FC61 /* AOObjectParserProtocol.h */; };
+		DC2AD4612020A4E100C9FC61 /* AOError.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD42D2020A4E100C9FC61 /* AOError.h */; };
+		DC2AD4622020A4E100C9FC61 /* AOAsynchBlockOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD42E2020A4E100C9FC61 /* AOAsynchBlockOperation.h */; };
+		DC2AD4632020A4E100C9FC61 /* NSString+AO.m in Sources */ = {isa = PBXBuildFile; fileRef = DC2AD42F2020A4E100C9FC61 /* NSString+AO.m */; };
+		DC2AD4642020A4E100C9FC61 /* AOFileUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = DC2AD4302020A4E100C9FC61 /* AOFileUtils.m */; };
+		DC2AD4652020A4E100C9FC61 /* NSArray+AO.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD4312020A4E100C9FC61 /* NSArray+AO.h */; };
+		DC2AD4662020A4E100C9FC61 /* AOError.m in Sources */ = {isa = PBXBuildFile; fileRef = DC2AD4322020A4E100C9FC61 /* AOError.m */; };
+		DC2AD4672020A4E100C9FC61 /* AOAsynchBlockOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = DC2AD4332020A4E100C9FC61 /* AOAsynchBlockOperation.m */; };
+		DC2AD4682020A4E100C9FC61 /* NSString+AO.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD4342020A4E100C9FC61 /* NSString+AO.h */; };
+		DC2AD4692020A4E100C9FC61 /* NSArray+AO.m in Sources */ = {isa = PBXBuildFile; fileRef = DC2AD4352020A4E100C9FC61 /* NSArray+AO.m */; };
+		DC2AD46A2020A4E100C9FC61 /* AOFileUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2AD4362020A4E100C9FC61 /* AOFileUtils.h */; };
 		E0666CFD60F86EC4A0F80A4F /* PINDiskCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 1D38AC160881372CDF9A0D36 /* PINDiskCache.m */; };
 		EF0AF1561B5B1CBD719B1E9D /* PINCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A21BD8ED62B36A9F8A2C37F /* PINCache.m */; };
 /* End PBXBuildFile section */
@@ -115,52 +121,6 @@
 		8CE8C7821FEC7E6A0041C284 /* AccedoOne.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AccedoOne.h; path = ../../Common/AccedoOne.h; sourceTree = "<group>"; };
 		8CE8C7831FEC7E6A0041C284 /* AccedoOne.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AccedoOne.m; path = ../../Common/AccedoOne.m; sourceTree = "<group>"; };
 		8CE8C78E1FEC7ECA0041C284 /* AccedoOnetvOS.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AccedoOnetvOS.pch; sourceTree = "<group>"; };
-		8CE8C7901FEC7EE20041C284 /* AOCMSOptionalParams.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AOCMSOptionalParams.m; path = ../../../Common/Service/AOCMSOptionalParams.m; sourceTree = "<group>"; };
-		8CE8C7911FEC7EE20041C284 /* AOServiceComponent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AOServiceComponent.h; path = ../../../Common/Service/AOServiceComponent.h; sourceTree = "<group>"; };
-		8CE8C7921FEC7EE20041C284 /* AOService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AOService.h; path = ../../../Common/Service/AOService.h; sourceTree = "<group>"; };
-		8CE8C7931FEC7EE20041C284 /* AOObjectParserProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AOObjectParserProtocol.h; path = ../../../Common/Service/AOObjectParserProtocol.h; sourceTree = "<group>"; };
-		8CE8C7941FEC7EE20041C284 /* AOService.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AOService.m; path = ../../../Common/Service/AOService.m; sourceTree = "<group>"; };
-		8CE8C7951FEC7EE20041C284 /* AOCMSOptionalParams.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AOCMSOptionalParams.h; path = ../../../Common/Service/AOCMSOptionalParams.h; sourceTree = "<group>"; };
-		8CE8C7961FEC7EE20041C284 /* AOServiceComponent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AOServiceComponent.m; path = ../../../Common/Service/AOServiceComponent.m; sourceTree = "<group>"; };
-		8CE8C79E1FEC7EF10041C284 /* AOPagingMetadata.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AOPagingMetadata.m; path = ../../../Common/Request/AOPagingMetadata.m; sourceTree = "<group>"; };
-		8CE8C79F1FEC7EF10041C284 /* AOPagingMetadata.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AOPagingMetadata.h; path = ../../../Common/Request/AOPagingMetadata.h; sourceTree = "<group>"; };
-		8CE8C7A01FEC7EF10041C284 /* AORequestMetadata.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AORequestMetadata.h; path = ../../../Common/Request/AORequestMetadata.h; sourceTree = "<group>"; };
-		8CE8C7A11FEC7EF10041C284 /* AORequestMetadata.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AORequestMetadata.m; path = ../../../Common/Request/AORequestMetadata.m; sourceTree = "<group>"; };
-		8CE8C7A61FEC7EFF0041C284 /* AOAsynchBlockOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AOAsynchBlockOperation.m; path = ../../../Common/Utils/AOAsynchBlockOperation.m; sourceTree = "<group>"; };
-		8CE8C7A71FEC7EFF0041C284 /* AOError.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AOError.m; path = ../../../Common/Utils/AOError.m; sourceTree = "<group>"; };
-		8CE8C7A81FEC7EFF0041C284 /* AOFileUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AOFileUtils.m; path = ../../../Common/Utils/AOFileUtils.m; sourceTree = "<group>"; };
-		8CE8C7A91FEC7EFF0041C284 /* AOError.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AOError.h; path = ../../../Common/Utils/AOError.h; sourceTree = "<group>"; };
-		8CE8C7AA1FEC7EFF0041C284 /* NSString+AO.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSString+AO.m"; path = "../../../Common/Utils/NSString+AO.m"; sourceTree = "<group>"; };
-		8CE8C7AB1FEC7EFF0041C284 /* NSArray+AO.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSArray+AO.h"; path = "../../../Common/Utils/NSArray+AO.h"; sourceTree = "<group>"; };
-		8CE8C7AC1FEC7EFF0041C284 /* NSArray+AO.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSArray+AO.m"; path = "../../../Common/Utils/NSArray+AO.m"; sourceTree = "<group>"; };
-		8CE8C7AD1FEC7EFF0041C284 /* AOAsynchBlockOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AOAsynchBlockOperation.h; path = ../../../Common/Utils/AOAsynchBlockOperation.h; sourceTree = "<group>"; };
-		8CE8C7AE1FEC7EFF0041C284 /* NSString+AO.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSString+AO.h"; path = "../../../Common/Utils/NSString+AO.h"; sourceTree = "<group>"; };
-		8CE8C7AF1FEC7EFF0041C284 /* AOFileUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AOFileUtils.h; path = ../../../Common/Utils/AOFileUtils.h; sourceTree = "<group>"; };
-		8CE8C7BA1FEC7F180041C284 /* AOCacheDTO.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AOCacheDTO.h; path = ../../../Common/Cache/AOCacheDTO.h; sourceTree = "<group>"; };
-		8CE8C7BB1FEC7F180041C284 /* AOCacheDTO.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AOCacheDTO.m; path = ../../../Common/Cache/AOCacheDTO.m; sourceTree = "<group>"; };
-		8CE8C7BC1FEC7F180041C284 /* AOCacheHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AOCacheHelper.m; path = ../../../Common/Cache/AOCacheHelper.m; sourceTree = "<group>"; };
-		8CE8C7BD1FEC7F180041C284 /* AOService+CacheController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "AOService+CacheController.h"; path = "../../../Common/Cache/AOService+CacheController.h"; sourceTree = "<group>"; };
-		8CE8C7BE1FEC7F180041C284 /* AOService+CacheController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "AOService+CacheController.m"; path = "../../../Common/Cache/AOService+CacheController.m"; sourceTree = "<group>"; };
-		8CE8C7BF1FEC7F180041C284 /* AOCacheHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AOCacheHelper.h; path = ../../../Common/Cache/AOCacheHelper.h; sourceTree = "<group>"; };
-		8CE8C7C01FEC7F180041C284 /* AOCacheHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AOCacheHandler.h; path = ../../../Common/Cache/AOCacheHandler.h; sourceTree = "<group>"; };
-		8CE8C7C81FEC7F2B0041C284 /* AOCacheOverPINCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AOCacheOverPINCache.m; path = ../../../../Common/Cache/Providers/AOCacheOverPINCache.m; sourceTree = "<group>"; };
-		8CE8C7CA1FEC7F2B0041C284 /* AOCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AOCache.h; path = ../../../../Common/Cache/Providers/AOCache.h; sourceTree = "<group>"; };
-		8CE8C7CB1FEC7F2B0041C284 /* AOCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AOCache.m; path = ../../../../Common/Cache/Providers/AOCache.m; sourceTree = "<group>"; };
-		8CE8C7CC1FEC7F2B0041C284 /* AOCacheOverPINCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AOCacheOverPINCache.h; path = ../../../../Common/Cache/Providers/AOCacheOverPINCache.h; sourceTree = "<group>"; };
-		8CE8C7CD1FEC7F2B0041C284 /* AOCacheOverNSCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AOCacheOverNSCache.h; path = ../../../../Common/Cache/Providers/AOCacheOverNSCache.h; sourceTree = "<group>"; };
-		8CE8C7CE1FEC7F2B0041C284 /* AOCacheOverNSCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AOCacheOverNSCache.m; path = ../../../../Common/Cache/Providers/AOCacheOverNSCache.m; sourceTree = "<group>"; };
-		8CE8C7D61FEC7F3E0041C284 /* AOCacheAtom.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AOCacheAtom.h; path = ../../../../../Common/Cache/Providers/Model/AOCacheAtom.h; sourceTree = "<group>"; };
-		8CE8C7D71FEC7F3E0041C284 /* AOCacheAtom.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AOCacheAtom.m; path = ../../../../../Common/Cache/Providers/Model/AOCacheAtom.m; sourceTree = "<group>"; };
-		8CF755B31FED3B50000D7070 /* AccedoOneInsight.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AccedoOneInsight.h; path = ../../../Common/API/AccedoOneInsight.h; sourceTree = "<group>"; };
-		8CF755B41FED3B50000D7070 /* AccedoOneUserData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AccedoOneUserData.h; path = ../../../Common/API/AccedoOneUserData.h; sourceTree = "<group>"; };
-		8CF755B51FED3B50000D7070 /* AccedoOneInsight.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AccedoOneInsight.m; path = ../../../Common/API/AccedoOneInsight.m; sourceTree = "<group>"; };
-		8CF755B61FED3B50000D7070 /* AccedoOneDetect.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AccedoOneDetect.m; path = ../../../Common/API/AccedoOneDetect.m; sourceTree = "<group>"; };
-		8CF755B71FED3B50000D7070 /* AccedoOneDetect.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AccedoOneDetect.h; path = ../../../Common/API/AccedoOneDetect.h; sourceTree = "<group>"; };
-		8CF755B81FED3B50000D7070 /* AccedoOneControl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AccedoOneControl.h; path = ../../../Common/API/AccedoOneControl.h; sourceTree = "<group>"; };
-		8CF755B91FED3B50000D7070 /* AccedoOnePublish.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AccedoOnePublish.h; path = ../../../Common/API/AccedoOnePublish.h; sourceTree = "<group>"; };
-		8CF755BA1FED3B50000D7070 /* AccedoOneControl.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AccedoOneControl.m; path = ../../../Common/API/AccedoOneControl.m; sourceTree = "<group>"; };
-		8CF755BB1FED3B50000D7070 /* AccedoOneUserData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AccedoOneUserData.m; path = ../../../Common/API/AccedoOneUserData.m; sourceTree = "<group>"; };
-		8CF755BC1FED3B50000D7070 /* AccedoOnePublish.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AccedoOnePublish.m; path = ../../../Common/API/AccedoOnePublish.m; sourceTree = "<group>"; };
 		90EFC088A0B42467801D03AE /* AFURLRequestSerialization.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFURLRequestSerialization.h; path = AccedoOnetvOS/Libraries/AFNetworking/AFURLRequestSerialization.h; sourceTree = "<group>"; };
 		98B06F0309ED0B071376DFB2 /* AFNetworkReachabilityManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFNetworkReachabilityManager.h; path = AccedoOnetvOS/Libraries/AFNetworking/AFNetworkReachabilityManager.h; sourceTree = "<group>"; };
 		A966E324C01A1BE08B761EC0 /* AFHTTPSessionManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFHTTPSessionManager.m; path = AccedoOnetvOS/Libraries/AFNetworking/AFHTTPSessionManager.m; sourceTree = "<group>"; };
@@ -168,6 +128,58 @@
 		C976D427024A762BEB948054 /* AFURLResponseSerialization.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFURLResponseSerialization.m; path = AccedoOnetvOS/Libraries/AFNetworking/AFURLResponseSerialization.m; sourceTree = "<group>"; };
 		D6D54405BC271BEB7125EBFE /* PINCacheDependencies.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = PINCacheDependencies.h; path = AccedoOnetvOS/Libraries/Symbols/PINCacheDependencies.h; sourceTree = "<group>"; };
 		D91BE977DBD7D1FE179AD89F /* AFURLRequestSerialization.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFURLRequestSerialization.m; path = AccedoOnetvOS/Libraries/AFNetworking/AFURLRequestSerialization.m; sourceTree = "<group>"; };
+		DC2AD3FC2020A4E000C9FC61 /* AOCacheDTO.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AOCacheDTO.h; sourceTree = "<group>"; };
+		DC2AD3FD2020A4E000C9FC61 /* AOService+CacheController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "AOService+CacheController.h"; sourceTree = "<group>"; };
+		DC2AD3FE2020A4E000C9FC61 /* AOCacheHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AOCacheHelper.m; sourceTree = "<group>"; };
+		DC2AD4002020A4E000C9FC61 /* AOCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AOCache.h; sourceTree = "<group>"; };
+		DC2AD4012020A4E000C9FC61 /* AOCacheOverNSCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AOCacheOverNSCache.h; sourceTree = "<group>"; };
+		DC2AD4022020A4E000C9FC61 /* AOCacheOverPINCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AOCacheOverPINCache.h; sourceTree = "<group>"; };
+		DC2AD4042020A4E000C9FC61 /* AOCacheAtom.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AOCacheAtom.m; sourceTree = "<group>"; };
+		DC2AD4052020A4E000C9FC61 /* AOCacheAtom.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AOCacheAtom.h; sourceTree = "<group>"; };
+		DC2AD4062020A4E000C9FC61 /* AOCacheOverPINCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AOCacheOverPINCache.m; sourceTree = "<group>"; };
+		DC2AD4072020A4E000C9FC61 /* AOCacheOverNSCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AOCacheOverNSCache.m; sourceTree = "<group>"; };
+		DC2AD4082020A4E000C9FC61 /* AOCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AOCache.m; sourceTree = "<group>"; };
+		DC2AD4092020A4E000C9FC61 /* AOService+CacheController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "AOService+CacheController.m"; sourceTree = "<group>"; };
+		DC2AD40A2020A4E000C9FC61 /* AOCacheDTO.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AOCacheDTO.m; sourceTree = "<group>"; };
+		DC2AD40B2020A4E000C9FC61 /* AOCacheHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AOCacheHelper.h; sourceTree = "<group>"; };
+		DC2AD40C2020A4E000C9FC61 /* AOCacheHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AOCacheHandler.h; sourceTree = "<group>"; };
+		DC2AD40E2020A4E000C9FC61 /* AORequestMetadata.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AORequestMetadata.m; sourceTree = "<group>"; };
+		DC2AD40F2020A4E000C9FC61 /* AOPagingMetadata.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AOPagingMetadata.m; sourceTree = "<group>"; };
+		DC2AD4102020A4E000C9FC61 /* AOPagingMetadata.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AOPagingMetadata.h; sourceTree = "<group>"; };
+		DC2AD4112020A4E000C9FC61 /* AORequestMetadata.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AORequestMetadata.h; sourceTree = "<group>"; };
+		DC2AD4132020A4E100C9FC61 /* AccedoOneControl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AccedoOneControl.h; sourceTree = "<group>"; };
+		DC2AD4142020A4E100C9FC61 /* AccedoOnePublish.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AccedoOnePublish.m; sourceTree = "<group>"; };
+		DC2AD4152020A4E100C9FC61 /* AccedoOneInsight.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AccedoOneInsight.m; sourceTree = "<group>"; };
+		DC2AD4162020A4E100C9FC61 /* AccedoOneDetect.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AccedoOneDetect.h; sourceTree = "<group>"; };
+		DC2AD4172020A4E100C9FC61 /* AccedoOneUserData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AccedoOneUserData.h; sourceTree = "<group>"; };
+		DC2AD4182020A4E100C9FC61 /* AccedoOneControl.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AccedoOneControl.m; sourceTree = "<group>"; };
+		DC2AD4192020A4E100C9FC61 /* AccedoOneInsight.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AccedoOneInsight.h; sourceTree = "<group>"; };
+		DC2AD41A2020A4E100C9FC61 /* AccedoOnePublish.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AccedoOnePublish.h; sourceTree = "<group>"; };
+		DC2AD41B2020A4E100C9FC61 /* AccedoOneDetect.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AccedoOneDetect.m; sourceTree = "<group>"; };
+		DC2AD41C2020A4E100C9FC61 /* AccedoOneUserData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AccedoOneUserData.m; sourceTree = "<group>"; };
+		DC2AD41E2020A4E100C9FC61 /* AccedoOneInsightProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AccedoOneInsightProtocol.h; sourceTree = "<group>"; };
+		DC2AD41F2020A4E100C9FC61 /* AccedoOneDetectProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AccedoOneDetectProtocol.h; sourceTree = "<group>"; };
+		DC2AD4202020A4E100C9FC61 /* AccedoOneUserDataProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AccedoOneUserDataProtocol.h; sourceTree = "<group>"; };
+		DC2AD4212020A4E100C9FC61 /* AccedoOnePublishProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AccedoOnePublishProtocol.h; sourceTree = "<group>"; };
+		DC2AD4222020A4E100C9FC61 /* AccedoOneCacheProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AccedoOneCacheProtocol.h; sourceTree = "<group>"; };
+		DC2AD4232020A4E100C9FC61 /* AccedoOneControlProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AccedoOneControlProtocol.h; sourceTree = "<group>"; };
+		DC2AD4252020A4E100C9FC61 /* AOService.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AOService.m; sourceTree = "<group>"; };
+		DC2AD4262020A4E100C9FC61 /* AOServiceComponent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AOServiceComponent.h; sourceTree = "<group>"; };
+		DC2AD4272020A4E100C9FC61 /* AOCMSOptionalParams.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AOCMSOptionalParams.h; sourceTree = "<group>"; };
+		DC2AD4282020A4E100C9FC61 /* AOService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AOService.h; sourceTree = "<group>"; };
+		DC2AD4292020A4E100C9FC61 /* AOCMSOptionalParams.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AOCMSOptionalParams.m; sourceTree = "<group>"; };
+		DC2AD42A2020A4E100C9FC61 /* AOServiceComponent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AOServiceComponent.m; sourceTree = "<group>"; };
+		DC2AD42B2020A4E100C9FC61 /* AOObjectParserProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AOObjectParserProtocol.h; sourceTree = "<group>"; };
+		DC2AD42D2020A4E100C9FC61 /* AOError.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AOError.h; sourceTree = "<group>"; };
+		DC2AD42E2020A4E100C9FC61 /* AOAsynchBlockOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AOAsynchBlockOperation.h; sourceTree = "<group>"; };
+		DC2AD42F2020A4E100C9FC61 /* NSString+AO.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+AO.m"; sourceTree = "<group>"; };
+		DC2AD4302020A4E100C9FC61 /* AOFileUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AOFileUtils.m; sourceTree = "<group>"; };
+		DC2AD4312020A4E100C9FC61 /* NSArray+AO.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSArray+AO.h"; sourceTree = "<group>"; };
+		DC2AD4322020A4E100C9FC61 /* AOError.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AOError.m; sourceTree = "<group>"; };
+		DC2AD4332020A4E100C9FC61 /* AOAsynchBlockOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AOAsynchBlockOperation.m; sourceTree = "<group>"; };
+		DC2AD4342020A4E100C9FC61 /* NSString+AO.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+AO.h"; sourceTree = "<group>"; };
+		DC2AD4352020A4E100C9FC61 /* NSArray+AO.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSArray+AO.m"; sourceTree = "<group>"; };
+		DC2AD4362020A4E100C9FC61 /* AOFileUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AOFileUtils.h; sourceTree = "<group>"; };
 		E8C40C071D6219C4C25780E3 /* AFURLSessionManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFURLSessionManager.h; path = AccedoOnetvOS/Libraries/AFNetworking/AFURLSessionManager.h; sourceTree = "<group>"; };
 		EA39A3BDDCE8DEAE1134E26A /* AFURLSessionManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFURLSessionManager.m; path = AccedoOnetvOS/Libraries/AFNetworking/AFURLSessionManager.m; sourceTree = "<group>"; };
 		EB84B9BAB9AE77EE05FAC625 /* AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFNetworking.h; path = AccedoOnetvOS/Libraries/AFNetworking/AFNetworking.h; sourceTree = "<group>"; };
@@ -217,11 +229,12 @@
 		8CE8C70D1FEC79E50041C284 /* AccedoOnetvOS */ = {
 			isa = PBXGroup;
 			children = (
-				8CF755B21FED3B3F000D7070 /* API */,
-				8CE8C78D1FEC7E9E0041C284 /* Service */,
-				8CE8C78C1FEC7E970041C284 /* Request */,
-				8CE8C78B1FEC7E890041C284 /* Utils */,
-				8CE8C7881FEC7E740041C284 /* Cache */,
+				DC2AD4122020A4E100C9FC61 /* API */,
+				DC2AD3FB2020A4E000C9FC61 /* Cache */,
+				DC2AD41D2020A4E100C9FC61 /* Protocols */,
+				DC2AD40D2020A4E000C9FC61 /* Request */,
+				DC2AD4242020A4E100C9FC61 /* Service */,
+				DC2AD42C2020A4E100C9FC61 /* Utils */,
 				8CE8C7821FEC7E6A0041C284 /* AccedoOne.h */,
 				8CE8C7831FEC7E6A0041C284 /* AccedoOne.m */,
 				8CE8C70E1FEC79E50041C284 /* AccedoOnetvOS.h */,
@@ -238,103 +251,6 @@
 				8CE8C71B1FEC79E50041C284 /* Info.plist */,
 			);
 			path = AccedoOnetvOSTests;
-			sourceTree = "<group>";
-		};
-		8CE8C7881FEC7E740041C284 /* Cache */ = {
-			isa = PBXGroup;
-			children = (
-				8CE8C7BA1FEC7F180041C284 /* AOCacheDTO.h */,
-				8CE8C7BB1FEC7F180041C284 /* AOCacheDTO.m */,
-				8CE8C7C01FEC7F180041C284 /* AOCacheHandler.h */,
-				8CE8C7BF1FEC7F180041C284 /* AOCacheHelper.h */,
-				8CE8C7BC1FEC7F180041C284 /* AOCacheHelper.m */,
-				8CE8C7BD1FEC7F180041C284 /* AOService+CacheController.h */,
-				8CE8C7BE1FEC7F180041C284 /* AOService+CacheController.m */,
-				8CE8C7891FEC7E7A0041C284 /* Providers */,
-			);
-			path = Cache;
-			sourceTree = "<group>";
-		};
-		8CE8C7891FEC7E7A0041C284 /* Providers */ = {
-			isa = PBXGroup;
-			children = (
-				8CE8C7CA1FEC7F2B0041C284 /* AOCache.h */,
-				8CE8C7CB1FEC7F2B0041C284 /* AOCache.m */,
-				8CE8C7CD1FEC7F2B0041C284 /* AOCacheOverNSCache.h */,
-				8CE8C7CE1FEC7F2B0041C284 /* AOCacheOverNSCache.m */,
-				8CE8C7CC1FEC7F2B0041C284 /* AOCacheOverPINCache.h */,
-				8CE8C7C81FEC7F2B0041C284 /* AOCacheOverPINCache.m */,
-				8CE8C78A1FEC7E810041C284 /* Model */,
-			);
-			path = Providers;
-			sourceTree = "<group>";
-		};
-		8CE8C78A1FEC7E810041C284 /* Model */ = {
-			isa = PBXGroup;
-			children = (
-				8CE8C7D61FEC7F3E0041C284 /* AOCacheAtom.h */,
-				8CE8C7D71FEC7F3E0041C284 /* AOCacheAtom.m */,
-			);
-			path = Model;
-			sourceTree = "<group>";
-		};
-		8CE8C78B1FEC7E890041C284 /* Utils */ = {
-			isa = PBXGroup;
-			children = (
-				8CE8C7AD1FEC7EFF0041C284 /* AOAsynchBlockOperation.h */,
-				8CE8C7A61FEC7EFF0041C284 /* AOAsynchBlockOperation.m */,
-				8CE8C7A91FEC7EFF0041C284 /* AOError.h */,
-				8CE8C7A71FEC7EFF0041C284 /* AOError.m */,
-				8CE8C7AF1FEC7EFF0041C284 /* AOFileUtils.h */,
-				8CE8C7A81FEC7EFF0041C284 /* AOFileUtils.m */,
-				8CE8C7AB1FEC7EFF0041C284 /* NSArray+AO.h */,
-				8CE8C7AC1FEC7EFF0041C284 /* NSArray+AO.m */,
-				8CE8C7AE1FEC7EFF0041C284 /* NSString+AO.h */,
-				8CE8C7AA1FEC7EFF0041C284 /* NSString+AO.m */,
-			);
-			path = Utils;
-			sourceTree = "<group>";
-		};
-		8CE8C78C1FEC7E970041C284 /* Request */ = {
-			isa = PBXGroup;
-			children = (
-				8CE8C79F1FEC7EF10041C284 /* AOPagingMetadata.h */,
-				8CE8C79E1FEC7EF10041C284 /* AOPagingMetadata.m */,
-				8CE8C7A01FEC7EF10041C284 /* AORequestMetadata.h */,
-				8CE8C7A11FEC7EF10041C284 /* AORequestMetadata.m */,
-			);
-			path = Request;
-			sourceTree = "<group>";
-		};
-		8CE8C78D1FEC7E9E0041C284 /* Service */ = {
-			isa = PBXGroup;
-			children = (
-				8CE8C7951FEC7EE20041C284 /* AOCMSOptionalParams.h */,
-				8CE8C7901FEC7EE20041C284 /* AOCMSOptionalParams.m */,
-				8CE8C7931FEC7EE20041C284 /* AOObjectParserProtocol.h */,
-				8CE8C7921FEC7EE20041C284 /* AOService.h */,
-				8CE8C7941FEC7EE20041C284 /* AOService.m */,
-				8CE8C7911FEC7EE20041C284 /* AOServiceComponent.h */,
-				8CE8C7961FEC7EE20041C284 /* AOServiceComponent.m */,
-			);
-			path = Service;
-			sourceTree = "<group>";
-		};
-		8CF755B21FED3B3F000D7070 /* API */ = {
-			isa = PBXGroup;
-			children = (
-				8CF755B81FED3B50000D7070 /* AccedoOneControl.h */,
-				8CF755BA1FED3B50000D7070 /* AccedoOneControl.m */,
-				8CF755B71FED3B50000D7070 /* AccedoOneDetect.h */,
-				8CF755B61FED3B50000D7070 /* AccedoOneDetect.m */,
-				8CF755B31FED3B50000D7070 /* AccedoOneInsight.h */,
-				8CF755B51FED3B50000D7070 /* AccedoOneInsight.m */,
-				8CF755B91FED3B50000D7070 /* AccedoOnePublish.h */,
-				8CF755BC1FED3B50000D7070 /* AccedoOnePublish.m */,
-				8CF755B41FED3B50000D7070 /* AccedoOneUserData.h */,
-				8CF755BB1FED3B50000D7070 /* AccedoOneUserData.m */,
-			);
-			path = API;
 			sourceTree = "<group>";
 		};
 		B3A19992AE8CD774416C09E7 /* AFNetworking */ = {
@@ -355,6 +271,122 @@
 				BD73EEFA6EB617336E8A21F3 /* AFHTTPSessionManager.h */,
 			);
 			name = AFNetworking;
+			sourceTree = "<group>";
+		};
+		DC2AD3FB2020A4E000C9FC61 /* Cache */ = {
+			isa = PBXGroup;
+			children = (
+				DC2AD3FF2020A4E000C9FC61 /* Providers */,
+				DC2AD3FC2020A4E000C9FC61 /* AOCacheDTO.h */,
+				DC2AD40A2020A4E000C9FC61 /* AOCacheDTO.m */,
+				DC2AD3FE2020A4E000C9FC61 /* AOCacheHelper.m */,
+				DC2AD3FD2020A4E000C9FC61 /* AOService+CacheController.h */,
+				DC2AD4092020A4E000C9FC61 /* AOService+CacheController.m */,
+				DC2AD40B2020A4E000C9FC61 /* AOCacheHelper.h */,
+				DC2AD40C2020A4E000C9FC61 /* AOCacheHandler.h */,
+			);
+			name = Cache;
+			path = ../../Common/Cache;
+			sourceTree = "<group>";
+		};
+		DC2AD3FF2020A4E000C9FC61 /* Providers */ = {
+			isa = PBXGroup;
+			children = (
+				DC2AD4002020A4E000C9FC61 /* AOCache.h */,
+				DC2AD4012020A4E000C9FC61 /* AOCacheOverNSCache.h */,
+				DC2AD4022020A4E000C9FC61 /* AOCacheOverPINCache.h */,
+				DC2AD4032020A4E000C9FC61 /* Model */,
+				DC2AD4062020A4E000C9FC61 /* AOCacheOverPINCache.m */,
+				DC2AD4072020A4E000C9FC61 /* AOCacheOverNSCache.m */,
+				DC2AD4082020A4E000C9FC61 /* AOCache.m */,
+			);
+			path = Providers;
+			sourceTree = "<group>";
+		};
+		DC2AD4032020A4E000C9FC61 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				DC2AD4042020A4E000C9FC61 /* AOCacheAtom.m */,
+				DC2AD4052020A4E000C9FC61 /* AOCacheAtom.h */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
+		DC2AD40D2020A4E000C9FC61 /* Request */ = {
+			isa = PBXGroup;
+			children = (
+				DC2AD4102020A4E000C9FC61 /* AOPagingMetadata.h */,
+				DC2AD40F2020A4E000C9FC61 /* AOPagingMetadata.m */,
+				DC2AD4112020A4E000C9FC61 /* AORequestMetadata.h */,
+				DC2AD40E2020A4E000C9FC61 /* AORequestMetadata.m */,
+			);
+			name = Request;
+			path = ../../Common/Request;
+			sourceTree = "<group>";
+		};
+		DC2AD4122020A4E100C9FC61 /* API */ = {
+			isa = PBXGroup;
+			children = (
+				DC2AD4132020A4E100C9FC61 /* AccedoOneControl.h */,
+				DC2AD4182020A4E100C9FC61 /* AccedoOneControl.m */,
+				DC2AD4162020A4E100C9FC61 /* AccedoOneDetect.h */,
+				DC2AD41B2020A4E100C9FC61 /* AccedoOneDetect.m */,
+				DC2AD4192020A4E100C9FC61 /* AccedoOneInsight.h */,
+				DC2AD4152020A4E100C9FC61 /* AccedoOneInsight.m */,
+				DC2AD41A2020A4E100C9FC61 /* AccedoOnePublish.h */,
+				DC2AD4142020A4E100C9FC61 /* AccedoOnePublish.m */,
+				DC2AD4172020A4E100C9FC61 /* AccedoOneUserData.h */,
+				DC2AD41C2020A4E100C9FC61 /* AccedoOneUserData.m */,
+			);
+			name = API;
+			path = ../../Common/API;
+			sourceTree = "<group>";
+		};
+		DC2AD41D2020A4E100C9FC61 /* Protocols */ = {
+			isa = PBXGroup;
+			children = (
+				DC2AD4232020A4E100C9FC61 /* AccedoOneControlProtocol.h */,
+				DC2AD41F2020A4E100C9FC61 /* AccedoOneDetectProtocol.h */,
+				DC2AD41E2020A4E100C9FC61 /* AccedoOneInsightProtocol.h */,
+				DC2AD4212020A4E100C9FC61 /* AccedoOnePublishProtocol.h */,
+				DC2AD4202020A4E100C9FC61 /* AccedoOneUserDataProtocol.h */,
+				DC2AD4222020A4E100C9FC61 /* AccedoOneCacheProtocol.h */,
+			);
+			name = Protocols;
+			path = ../../Common/Protocols;
+			sourceTree = "<group>";
+		};
+		DC2AD4242020A4E100C9FC61 /* Service */ = {
+			isa = PBXGroup;
+			children = (
+				DC2AD4282020A4E100C9FC61 /* AOService.h */,
+				DC2AD4252020A4E100C9FC61 /* AOService.m */,
+				DC2AD4262020A4E100C9FC61 /* AOServiceComponent.h */,
+				DC2AD42A2020A4E100C9FC61 /* AOServiceComponent.m */,
+				DC2AD4272020A4E100C9FC61 /* AOCMSOptionalParams.h */,
+				DC2AD4292020A4E100C9FC61 /* AOCMSOptionalParams.m */,
+				DC2AD42B2020A4E100C9FC61 /* AOObjectParserProtocol.h */,
+			);
+			name = Service;
+			path = ../../Common/Service;
+			sourceTree = "<group>";
+		};
+		DC2AD42C2020A4E100C9FC61 /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				DC2AD42D2020A4E100C9FC61 /* AOError.h */,
+				DC2AD4322020A4E100C9FC61 /* AOError.m */,
+				DC2AD4342020A4E100C9FC61 /* NSString+AO.h */,
+				DC2AD42F2020A4E100C9FC61 /* NSString+AO.m */,
+				DC2AD4312020A4E100C9FC61 /* NSArray+AO.h */,
+				DC2AD4352020A4E100C9FC61 /* NSArray+AO.m */,
+				DC2AD42E2020A4E100C9FC61 /* AOAsynchBlockOperation.h */,
+				DC2AD4332020A4E100C9FC61 /* AOAsynchBlockOperation.m */,
+				DC2AD4362020A4E100C9FC61 /* AOFileUtils.h */,
+				DC2AD4302020A4E100C9FC61 /* AOFileUtils.m */,
+			);
+			name = Utils;
+			path = ../../Common/Utils;
 			sourceTree = "<group>";
 		};
 		DE466F672BD53F89E80B1D08 /* PINCache */ = {
@@ -387,33 +419,39 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8CE8C7B71FEC7EFF0041C284 /* AOAsynchBlockOperation.h in Headers */,
-				8CE8C7B31FEC7EFF0041C284 /* AOError.h in Headers */,
-				8CE8C7A41FEC7EF10041C284 /* AORequestMetadata.h in Headers */,
-				8CE8C7991FEC7EE20041C284 /* AOService.h in Headers */,
-				8CE8C7981FEC7EE20041C284 /* AOServiceComponent.h in Headers */,
-				8CE8C7C71FEC7F180041C284 /* AOCacheHandler.h in Headers */,
-				8CF755C31FED3B50000D7070 /* AccedoOnePublish.h in Headers */,
-				8CF755BD1FED3B50000D7070 /* AccedoOneInsight.h in Headers */,
-				8CF755C11FED3B50000D7070 /* AccedoOneDetect.h in Headers */,
-				8CF755BE1FED3B50000D7070 /* AccedoOneUserData.h in Headers */,
-				8CF755C21FED3B50000D7070 /* AccedoOneControl.h in Headers */,
-				8CE8C7A31FEC7EF10041C284 /* AOPagingMetadata.h in Headers */,
-				8CE8C79A1FEC7EE20041C284 /* AOObjectParserProtocol.h in Headers */,
 				8CE8C7851FEC7E6B0041C284 /* AccedoOne.h in Headers */,
-				8CE8C7D11FEC7F2B0041C284 /* AOCache.h in Headers */,
-				8CE8C7D81FEC7F3E0041C284 /* AOCacheAtom.h in Headers */,
+				DC2AD44D2020A4E100C9FC61 /* AccedoOneDetect.h in Headers */,
+				DC2AD45C2020A4E100C9FC61 /* AOCMSOptionalParams.h in Headers */,
+				DC2AD43A2020A4E100C9FC61 /* AOCache.h in Headers */,
+				DC2AD44E2020A4E100C9FC61 /* AccedoOneUserData.h in Headers */,
+				DC2AD4572020A4E100C9FC61 /* AccedoOnePublishProtocol.h in Headers */,
+				DC2AD4622020A4E100C9FC61 /* AOAsynchBlockOperation.h in Headers */,
+				DC2AD4512020A4E100C9FC61 /* AccedoOnePublish.h in Headers */,
+				DC2AD4652020A4E100C9FC61 /* NSArray+AO.h in Headers */,
+				DC2AD4372020A4E100C9FC61 /* AOCacheDTO.h in Headers */,
+				DC2AD4502020A4E100C9FC61 /* AccedoOneInsight.h in Headers */,
+				DC2AD45D2020A4E100C9FC61 /* AOService.h in Headers */,
 				8CE8C71C1FEC79E50041C284 /* AccedoOnetvOS.h in Headers */,
-				8CE8C7B81FEC7EFF0041C284 /* NSString+AO.h in Headers */,
-				8CE8C7D41FEC7F2B0041C284 /* AOCacheOverNSCache.h in Headers */,
-				8CE8C7C41FEC7F180041C284 /* AOService+CacheController.h in Headers */,
-				8CE8C7C11FEC7F180041C284 /* AOCacheDTO.h in Headers */,
 				8CE8C78F1FEC7ECA0041C284 /* AccedoOnetvOS.pch in Headers */,
-				8CE8C7D31FEC7F2B0041C284 /* AOCacheOverPINCache.h in Headers */,
-				8CE8C7B91FEC7EFF0041C284 /* AOFileUtils.h in Headers */,
-				8CE8C79C1FEC7EE20041C284 /* AOCMSOptionalParams.h in Headers */,
-				8CE8C7C61FEC7F180041C284 /* AOCacheHelper.h in Headers */,
-				8CE8C7B51FEC7EFF0041C284 /* NSArray+AO.h in Headers */,
+				DC2AD43B2020A4E100C9FC61 /* AOCacheOverNSCache.h in Headers */,
+				DC2AD4562020A4E100C9FC61 /* AccedoOneUserDataProtocol.h in Headers */,
+				DC2AD43E2020A4E100C9FC61 /* AOCacheAtom.h in Headers */,
+				DC2AD4482020A4E100C9FC61 /* AOPagingMetadata.h in Headers */,
+				DC2AD4602020A4E100C9FC61 /* AOObjectParserProtocol.h in Headers */,
+				DC2AD44A2020A4E100C9FC61 /* AccedoOneControl.h in Headers */,
+				DC2AD4542020A4E100C9FC61 /* AccedoOneInsightProtocol.h in Headers */,
+				DC2AD4452020A4E100C9FC61 /* AOCacheHandler.h in Headers */,
+				DC2AD4682020A4E100C9FC61 /* NSString+AO.h in Headers */,
+				DC2AD45B2020A4E100C9FC61 /* AOServiceComponent.h in Headers */,
+				DC2AD4552020A4E100C9FC61 /* AccedoOneDetectProtocol.h in Headers */,
+				DC2AD43C2020A4E100C9FC61 /* AOCacheOverPINCache.h in Headers */,
+				DC2AD4582020A4E100C9FC61 /* AccedoOneCacheProtocol.h in Headers */,
+				DC2AD4592020A4E100C9FC61 /* AccedoOneControlProtocol.h in Headers */,
+				DC2AD46A2020A4E100C9FC61 /* AOFileUtils.h in Headers */,
+				DC2AD4612020A4E100C9FC61 /* AOError.h in Headers */,
+				DC2AD4492020A4E100C9FC61 /* AORequestMetadata.h in Headers */,
+				DC2AD4382020A4E100C9FC61 /* AOService+CacheController.h in Headers */,
+				DC2AD4442020A4E100C9FC61 /* AOCacheHelper.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -536,37 +574,37 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8CE8C79B1FEC7EE20041C284 /* AOService.m in Sources */,
 				8CE8C7861FEC7E6B0041C284 /* AccedoOne.m in Sources */,
-				8CE8C7D51FEC7F2B0041C284 /* AOCacheOverNSCache.m in Sources */,
-				8CE8C7D91FEC7F3E0041C284 /* AOCacheAtom.m in Sources */,
-				8CE8C7C31FEC7F180041C284 /* AOCacheHelper.m in Sources */,
-				8CF755C61FED3B50000D7070 /* AccedoOnePublish.m in Sources */,
-				8CE8C7B61FEC7EFF0041C284 /* NSArray+AO.m in Sources */,
-				8CE8C7B01FEC7EFF0041C284 /* AOAsynchBlockOperation.m in Sources */,
-				8CE8C7B41FEC7EFF0041C284 /* NSString+AO.m in Sources */,
-				8CF755C01FED3B50000D7070 /* AccedoOneDetect.m in Sources */,
-				8CE8C7A51FEC7EF10041C284 /* AORequestMetadata.m in Sources */,
-				8CE8C7C21FEC7F180041C284 /* AOCacheDTO.m in Sources */,
-				8CE8C7D21FEC7F2B0041C284 /* AOCache.m in Sources */,
-				8CE8C7C51FEC7F180041C284 /* AOService+CacheController.m in Sources */,
-				8CF755C41FED3B50000D7070 /* AccedoOneControl.m in Sources */,
-				8CF755BF1FED3B50000D7070 /* AccedoOneInsight.m in Sources */,
-				8CE8C7CF1FEC7F2B0041C284 /* AOCacheOverPINCache.m in Sources */,
-				8CE8C7B21FEC7EFF0041C284 /* AOFileUtils.m in Sources */,
-				8CE8C7A21FEC7EF10041C284 /* AOPagingMetadata.m in Sources */,
-				8CE8C7971FEC7EE20041C284 /* AOCMSOptionalParams.m in Sources */,
-				8CE8C7B11FEC7EFF0041C284 /* AOError.m in Sources */,
-				8CE8C79D1FEC7EE20041C284 /* AOServiceComponent.m in Sources */,
+				DC2AD45F2020A4E100C9FC61 /* AOServiceComponent.m in Sources */,
+				DC2AD4692020A4E100C9FC61 /* NSArray+AO.m in Sources */,
+				DC2AD4412020A4E100C9FC61 /* AOCache.m in Sources */,
+				DC2AD4462020A4E100C9FC61 /* AORequestMetadata.m in Sources */,
+				DC2AD44F2020A4E100C9FC61 /* AccedoOneControl.m in Sources */,
+				DC2AD4672020A4E100C9FC61 /* AOAsynchBlockOperation.m in Sources */,
 				2BAC7FDC9BB9292247C1FEEA /* AFURLResponseSerialization.m in Sources */,
+				DC2AD4402020A4E100C9FC61 /* AOCacheOverNSCache.m in Sources */,
 				80A8AAA01AA9D337FA7BC343 /* AFHTTPSessionManager.m in Sources */,
+				DC2AD43F2020A4E100C9FC61 /* AOCacheOverPINCache.m in Sources */,
 				B5BF2C33B9183F5B27F6FE44 /* AFURLSessionManager.m in Sources */,
+				DC2AD4662020A4E100C9FC61 /* AOError.m in Sources */,
+				DC2AD4472020A4E100C9FC61 /* AOPagingMetadata.m in Sources */,
+				DC2AD4632020A4E100C9FC61 /* NSString+AO.m in Sources */,
+				DC2AD4432020A4E100C9FC61 /* AOCacheDTO.m in Sources */,
 				97015C22C3CAD8985863D8B9 /* AFURLRequestSerialization.m in Sources */,
 				9DD6D05F8FB8AD92B755E3F4 /* AFNetworkReachabilityManager.m in Sources */,
+				DC2AD44C2020A4E100C9FC61 /* AccedoOneInsight.m in Sources */,
 				5C4E55718DB1D50671EC233B /* AFSecurityPolicy.m in Sources */,
-				8CF755C51FED3B50000D7070 /* AccedoOneUserData.m in Sources */,
+				DC2AD4522020A4E100C9FC61 /* AccedoOneDetect.m in Sources */,
+				DC2AD4532020A4E100C9FC61 /* AccedoOneUserData.m in Sources */,
+				DC2AD44B2020A4E100C9FC61 /* AccedoOnePublish.m in Sources */,
+				DC2AD4642020A4E100C9FC61 /* AOFileUtils.m in Sources */,
+				DC2AD4422020A4E100C9FC61 /* AOService+CacheController.m in Sources */,
+				DC2AD45E2020A4E100C9FC61 /* AOCMSOptionalParams.m in Sources */,
+				DC2AD45A2020A4E100C9FC61 /* AOService.m in Sources */,
 				EF0AF1561B5B1CBD719B1E9D /* PINCache.m in Sources */,
 				061852C5EDE4E6AC11004AAD /* PINMemoryCache.m in Sources */,
+				DC2AD43D2020A4E100C9FC61 /* AOCacheAtom.m in Sources */,
+				DC2AD4392020A4E100C9FC61 /* AOCacheHelper.m in Sources */,
 				E0666CFD60F86EC4A0F80A4F /* PINDiskCache.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/AccedoOnetvOS/AccedoOnetvOS/Info.plist
+++ b/AccedoOnetvOS/AccedoOnetvOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.0.2</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Common/API/AccedoOneControl.h
+++ b/Common/API/AccedoOneControl.h
@@ -8,27 +8,16 @@
 //
 
 #import <Foundation/Foundation.h>
-
-
+#import "AccedoOneControlProtocol.h"
 
 @class AOError;
 @class AccedoOne;
 
-@interface AccedoOneControl : NSObject
--(instancetype _Nonnull ) initWithService:(AccedoOne *_Nonnull) service;
-- (void) applicationStatus:(void (^_Nonnull)(NSString * _Nullable status, NSString * _Nullable message,  AOError * _Nullable err))completionBlock;
-- (void) profileInfo:(nullable void (^)(NSDictionary* _Nullable profileInfo, AOError* _Nullable err))completionBlock;
-- (void) profileInfoForGID:(nullable NSString*)gid onComplete:(nullable void (^)(NSDictionary* _Nullable profileInfo, AOError* _Nullable err))completionBlock;
-- (void) allMetadata:(nullable void (^)(NSDictionary * _Nullable allMetadata, AOError * _Nullable err))completionBlock;
-- (void) allMetadataForGID:(nullable NSString *)gid onComplete:(nullable void (^)(NSDictionary * _Nullable allMetadata, AOError * _Nullable err))completionBlock;
+@interface AccedoOneControl : NSObject <AccedoOneControlProtocol>
 
-- (void) metadataForKey:(nonnull NSString *)key onComplete:(nullable void (^)(id _Nullable metadata, AOError * _Nullable error))completionBlock;
-- (void) metadataForKey:(nonnull NSString *)key gid:(nullable NSString *)gid onComplete:(nullable void (^)(id _Nullable metadata, AOError * _Nullable error))completionBlock;
-- (void) metadataForKeys:(nonnull NSArray<NSString *>*)keys gid:(nullable NSString *)gid onComplete:(nullable void (^)(id _Nullable metadata, AOError * _Nullable error))completionBlock;
-
-- (void) allAssets:(nullable void (^)(NSDictionary * _Nullable assetsMetadata, AOError *_Nullable err))completionBlock;
-- (void) assetForKey:(nonnull NSString *)key onComplete:(nullable void (^)(NSData * _Nullable asset, AOError * _Nullable err))completionBlock;
+- (instancetype _Nonnull) initWithService:(AccedoOne *_Nonnull) service;
 - (void) clearCache;
+
 @end
 
 

--- a/Common/API/AccedoOneDetect.h
+++ b/Common/API/AccedoOneDetect.h
@@ -8,30 +8,14 @@
 //
 
 #import <Foundation/Foundation.h>
-
-
-
-/**
- * Log level types used for remote logging
- */
-typedef NS_ENUM(NSUInteger, AOServiceLogLevel) {
-    AOServiceLogLevelNotInitialized = NSNotFound,
-    AOServiceLogLevelOff            = 0,
-    AOServiceLogLevelError          = 1,
-    AOServiceLogLevelWarn           = 2,
-    AOServiceLogLevelInfo           = 3,
-    AOServiceLogLevelDebug          = 4
-};
+#import "AccedoOneDetectProtocol.h"
 
 @class AccedoOne;
 
-@interface AccedoOneDetect : NSObject
--(instancetype _Nonnull ) initWithService:(nonnull AccedoOne *) service;
+@interface AccedoOneDetect : NSObject <AccedoOneDetectProtocol>
 
-- (void) logWithLevel:(AOServiceLogLevel)logLevel code:(NSUInteger)code message:(nonnull  NSString *)message dimensions:(nullable NSDictionary *)dimensions;
+- (instancetype _Nonnull) initWithService:(nonnull AccedoOne *) service;
 
 @property (nonatomic, assign) AOServiceLogLevel logLevel;
 
 @end
-
-

--- a/Common/API/AccedoOneDetect.m
+++ b/Common/API/AccedoOneDetect.m
@@ -10,16 +10,16 @@
 #import "AccedoOneDetect.h"
 #import "AccedoOne.h"
 
-static NSString *const kPathLogLevel         = @"application/log/level";
-static NSString *const kPathLogDebug         = @"application/log/debug";
-static NSString *const kPathLogWarn          = @"application/log/warn";
-static NSString *const kPathLogError         = @"application/log/error";
-static NSString *const kPathLogInfo          = @"application/log/info";
-
+static NSString *const kPathLogLevel = @"application/log/level";
+static NSString *const kPathLogDebug = @"application/log/debug";
+static NSString *const kPathLogWarn  = @"application/log/warn";
+static NSString *const kPathLogError = @"application/log/error";
+static NSString *const kPathLogInfo  = @"application/log/info";
 
 @interface AccedoOneDetect ()
 @property (nonatomic, strong) AccedoOne * service;
 @end
+
 
 @implementation AccedoOneDetect
 
@@ -29,6 +29,8 @@ static NSString *const kPathLogInfo          = @"application/log/info";
     }
     return self;
 }
+
+#pragma mark - AccedoOneDetectProtocol
 
 /**
  *  Remote logging for debug and support purposes. Remote logging will only be fired if the requested log level (logLevel)
@@ -41,23 +43,18 @@ static NSString *const kPathLogInfo          = @"application/log/info";
  */
 - (void) logWithLevel:(AOServiceLogLevel)logLevel code:(NSUInteger)code message:(NSString *)message dimensions:(NSDictionary *)dimensions {
     
-    if (self.logLevel == AOServiceLogLevelNotInitialized)
-    {
-        [self getLevel:^(AOServiceLogLevel configuredLogLevel)
-         {
+    if (self.logLevel == AOServiceLogLevelNotInitialized) {
+        [self getLevel:^(AOServiceLogLevel configuredLogLevel) {
              [self logToRemoteServiceCode:code message:message dimensions:dimensions requestedLogLevel:logLevel];
-         }
-             onFailure:^(AOError *error)
-         {
+        } onFailure:^(AOError *error) {
              ELog(@"AO-[error]: AccedoOneService logWithLevel failed with error: %@", error);
-         }];
-    }
-    else
-    {
+        }];
+    } else {
         [self logToRemoteServiceCode:code message:message dimensions:dimensions requestedLogLevel:logLevel];
     }
 }
 
+#pragma mark - Utils
 
 /**
  *  Log to the remote server if the current log level allows it
@@ -70,10 +67,9 @@ static NSString *const kPathLogInfo          = @"application/log/info";
 - (void) logToRemoteServiceCode:(NSUInteger)code
                         message:(NSString *)message
                      dimensions:(NSDictionary *)dimensions
-              requestedLogLevel:(AOServiceLogLevel)requestedLogLevel
-{
-    if ((requestedLogLevel >= self.logLevel) && (self.logLevel != AOServiceLogLevelOff))
-    {
+              requestedLogLevel:(AOServiceLogLevel)requestedLogLevel {
+
+    if ((requestedLogLevel >= self.logLevel) && (self.logLevel != AOServiceLogLevelOff)) {
         //Code and message are mandatory parameters, and code must be 5 digits tops
         NSParameterAssert(code);
         NSParameterAssert(message);
@@ -94,24 +90,21 @@ static NSString *const kPathLogInfo          = @"application/log/info";
     }
 }
 
-
 /**
  *  Get log level for the application as configured in AccedoOne.
  */
-- (void) getLevel:(void (^)(AOServiceLogLevel configuredLogLevel))completionBlock onFailure:(AOErrorBlock)failureBlock
-{
-    [self.service sendAuthenticatedGETRequest:kPathLogLevel queryParams:nil allowCache:NO onSuccess:^(NSDictionary *response)
-     {
+- (void) getLevel:(void (^)(AOServiceLogLevel configuredLogLevel))completionBlock onFailure:(AOErrorBlock)failureBlock {
+
+    [self.service sendAuthenticatedGETRequest:kPathLogLevel queryParams:nil allowCache:NO onSuccess:^(NSDictionary *response) {
          NSString *remoteLogLevel = [response valueForKey:@"logLevel"];
-         
+
          self.logLevel = [self stringToLogLevelType:remoteLogLevel];
          
          if (completionBlock) {
              completionBlock(self.logLevel);
          }
-     }
-                                 failureBlock:^(AOError *error)
-     {
+
+    } failureBlock:^(AOError *error) {
          self.logLevel = AOServiceLogLevelOff;
          
          if (failureBlock) {
@@ -164,6 +157,7 @@ static NSString *const kPathLogInfo          = @"application/log/info";
     else {
         ELog(@"AO-[error]: AAccedoOneService failed to map logLevel (%@) to a known value (AccedoOneServiceLogLevel). Fallback to:  AccedoOneServiceLogLevelOff", logLevel);
     }
+
     return result;
 }
 

--- a/Common/API/AccedoOneInsight.h
+++ b/Common/API/AccedoOneInsight.h
@@ -9,20 +9,13 @@
 
 #import <Foundation/Foundation.h>
 #import "AOServiceComponent.h"
-
-
-
+#import "AccedoOneInsightProtocol.h"
 
 @class AccedoOne;
 
-@interface AccedoOneInsight : NSObject
--(instancetype _Nonnull ) initWithService:(AccedoOne *_Nonnull) service;
+@interface AccedoOneInsight : NSObject <AccedoOneInsightProtocol>
 
-- (void) applicationStart;
-- (void) applicationStartSuccess:(nullable AOSuccessBlock)completionBlock onFailure:(nullable AOErrorBlock)failureBlock;
-
-- (void) applicationStop;
-- (void) applicationStop:(BOOL)clearCache;
+- (instancetype _Nonnull) initWithService:(AccedoOne *_Nonnull) service;
 
 @end
 

--- a/Common/API/AccedoOneInsight.m
+++ b/Common/API/AccedoOneInsight.m
@@ -10,12 +10,13 @@
 #import "AccedoOneInsight.h"
 #import "AccedoOne.h"
 
-static NSString *const kPathAnalytics        = @"event/log";
+static NSString *const kPathAnalytics = @"event/log";
 
 @interface AccedoOneInsight ()
 @property (nonatomic, strong) AccedoOne * service;
 
 @end
+
 
 @implementation AccedoOneInsight
 
@@ -26,6 +27,7 @@ static NSString *const kPathAnalytics        = @"event/log";
     return self;
 }
 
+#pragma mark - AccedoOneInsightProtocol
 
 /**
  *  Log the application launch (simple)
@@ -38,7 +40,6 @@ static NSString *const kPathAnalytics        = @"event/log";
  *  Log the application launch
  */
 -(void) applicationStartSuccess:(AOSuccessBlock)completionBlock onFailure:(AOErrorBlock)failureBlock {
-    
     //[self sendAuthenticatedPOSTRequest:kPathAnalytics params:@{ @"eventType": @"START" } body:nil onSuccess:nil onFailure:nil];
     [self.service sendAuthenticatedPOSTRequest:kPathAnalytics params:nil body:[AORequestMetadata dictionaryToNSData:@{@"eventType": @"START"} error:nil] onSuccess:completionBlock onFailure:failureBlock];
 }
@@ -54,13 +55,8 @@ static NSString *const kPathAnalytics        = @"event/log";
  *  Log the application termination and optionally clear cache.
  */
 - (void) applicationStop:(BOOL)clearCache {
-    
     //[self sendAuthenticatedPOSTRequest:kPathAnalytics params:@{ @"eventType": @"QUIT" } body:nil onSuccess:nil onFailure:nil];
     [self.service sendAuthenticatedPOSTRequest:kPathAnalytics params:nil body:[AORequestMetadata dictionaryToNSData:@{@"eventType": @"QUIT"} error:nil] onSuccess:nil onFailure:nil];
-    
-   
 }
-
-
 
 @end

--- a/Common/API/AccedoOnePublish.h
+++ b/Common/API/AccedoOnePublish.h
@@ -8,35 +8,15 @@
 //
 
 #import <Foundation/Foundation.h>
-
-
+#import "AccedoOnePublishProtocol.h"
 
 @class AccedoOne;
 @class AOError;
 @class AOPageResult;
 @class AOCMSOptionalParams;
 
-@interface AccedoOnePublish : NSObject
--(instancetype _Nonnull ) initWithService:(AccedoOne *_Nonnull) service;
+@interface AccedoOnePublish : NSObject <AccedoOnePublishProtocol>
 
-- (void) entryForId:(nonnull NSString*)entryId onComplete:(nullable void (^)(NSDictionary * _Nullable entry, AOError * _Nullable err))completionBlock;
-- (void) entryForId:(nonnull NSString*)entryId optionalParams:(nullable AOCMSOptionalParams *)params onComplete:(nullable void (^)(NSDictionary * _Nullable entry, AOError * _Nullable err))completionBlock;
+- (instancetype _Nonnull) initWithService:(AccedoOne *_Nonnull) service;
 
-- (void) entriesForIds:(nonnull NSArray<__kindof NSString*>*)contentIds onComplete:(nullable void (^)(NSArray * _Nullable entries, AOError * _Nullable err))completionBlock;
-- (void) entriesForIds:(nonnull NSArray<__kindof NSString*>*)contentIds optionalParams:(nullable AOCMSOptionalParams *)params onComplete:(nullable void(^)(NSArray * _Nullable entries, AOError * _Nullable err))completionBlock;
-
-- (void) entriesForAliases:(nonnull NSArray<__kindof NSString*>*)aliases onComplete:(nullable void (^)(NSArray * _Nullable entries, AOError * _Nullable err))completionBlock;
-- (void) entriesForAliases:(nonnull NSArray<__kindof NSString*>*)aliases optionalParams:(nullable AOCMSOptionalParams *)params onComplete:(nullable void(^)(NSArray * _Nullable entries, AOError * _Nullable err))completionBlock;
-
-- (void) entriesForTypeAlias:(nonnull NSString*)alias onComplete:(nullable void (^)(NSArray * _Nullable entries, AOError * _Nullable err))completionBlock;
-- (void) entriesForTypeAlias:(nonnull NSString*)alias optionalParams:(nullable AOCMSOptionalParams *)params onComplete:(nullable void(^)(NSArray * _Nullable entries, AOError * _Nullable err))completionBlock;
-
-- (void) entriesForType:(nonnull NSString *)typeId onComplete:(nullable void (^)(AOPageResult * _Nullable result, AOError * _Nullable err))completionBlock;
-- (void) entriesForType:(nonnull NSString *)typeId optionalParams:(nullable AOCMSOptionalParams *)params onComplete:(nullable void(^)(AOPageResult * _Nullable result, AOError * _Nullable err))completionBlock;
-
-- (void) allEntries:(nullable void (^)(AOPageResult * _Nullable result, AOError * _Nullable err))completionBlock;
-- (void) allEntriesForParams:(nonnull AOCMSOptionalParams *)params onComplete:(nullable void (^)(AOPageResult * _Nullable result, AOError * _Nullable err))completionBlock;
--(void) localesOnComplete:(nullable void (^)(NSArray *_Nullable locales, AOError *_Nullable err))completionBlock;
 @end
-
-

--- a/Common/API/AccedoOnePublish.m
+++ b/Common/API/AccedoOnePublish.m
@@ -8,6 +8,7 @@
 //
 
 #import "AccedoOnePublish.h"
+
 #import "AccedoOne.h"
 #import "AOCMSOptionalParams.h"
 #import "AOPagingMetadata.h"
@@ -26,29 +27,33 @@ static NSString *const kPathLocales          = @"locales";
 -(instancetype) initWithService:(AccedoOne *) service {
     if (self = [super init]){
         _service = service;
-        self.queue         = [NSOperationQueue new];
-        self.queue.maxConcurrentOperationCount = 1; //FIFO with respect to operation order...
+        _queue = [NSOperationQueue new];
+        _queue.maxConcurrentOperationCount = 1; //FIFO with respect to operation order...
     }
     return self;
 }
 
+#pragma mark - AccedoOnePublishProtocol
+
 - (void) entryForId:(NSString*)entryId onComplete:(void (^)(NSDictionary *entry, AOError *err))completionBlock {
+
     if (! entryId) {
         if (completionBlock) completionBlock(nil, [AOError errorWithMessage:@"AccedoOneService: 'entryId' cannot be null!"]);
         return;
     }
-    
+
     AOCMSOptionalParams * params = [[AOCMSOptionalParams params] paramWithPreview:NO];
     
     [self entryForId:entryId optionalParams:params onComplete:completionBlock];
 }
 
 - (void) entryForId:(NSString*)entryId optionalParams:(AOCMSOptionalParams *)params onComplete:(void (^)(NSDictionary *entry, AOError *err))completionBlock {
+
     if (! entryId) {
         if (completionBlock) completionBlock(nil, [AOError errorWithMessage:@"AccedoOneService: 'entryId' cannot be null!"]);
         return;
     }
-    
+
     [self entriesForIds:@[entryId] optionalParams:params onComplete:^(NSArray *contents, AOError *err) {
         if (completionBlock) completionBlock([contents firstObject], err);
     }];
@@ -106,114 +111,102 @@ static NSString *const kPathLocales          = @"locales";
     
     paramsDict[@"typeId"] = typeId; //entryTypeId
     
-    [self.service sendAuthenticatedGETRequest:kPathContents queryParams:paramsDict allowCache:NO onSuccess:^(id response)
-     {
-         NSArray * entries = @[];
-         
-         if (response[@"entries"]) {
-             entries = response[@"entries"];
-         }
-         
-         AOPageData * pageData = nil;
-         
-         NSUInteger total = [entries count];
-         
-         if (response[@"pagination"]) {
-             total             = [response[@"pagination"][@"total"] unsignedLongValue];
-             NSUInteger offset = [response[@"pagination"][@"offset"] unsignedLongValue];
-             NSUInteger size   = [response[@"pagination"][@"size"] unsignedLongValue];
-             
-             pageData = [AOPageData pageDataWithOffset:offset pageSize:size];
-         }
-         
-         AOPageResult * pageResult = [AOPageResult pageResultWithContent:entries pageData:pageData totalCount:total];
-         
-         if (completionBlock) {
-             completionBlock(pageResult, nil);
-         }
-     }
-                         failureBlock:^(AOError *error)
-     {
+    [self.service sendAuthenticatedGETRequest:kPathContents queryParams:paramsDict allowCache:NO onSuccess:^(id response) {
+        NSArray * entries = @[];
+        
+        if (response[@"entries"]) {
+            entries = response[@"entries"];
+        }
+        
+        AOPageData * pageData = nil;
+        
+        NSUInteger total = [entries count];
+        
+        if (response[@"pagination"]) {
+            total             = [response[@"pagination"][@"total"] unsignedLongValue];
+            NSUInteger offset = [response[@"pagination"][@"offset"] unsignedLongValue];
+            NSUInteger size   = [response[@"pagination"][@"size"] unsignedLongValue];
+            
+            pageData = [AOPageData pageDataWithOffset:offset pageSize:size];
+        }
+        
+        AOPageResult * pageResult = [AOPageResult pageResultWithContent:entries pageData:pageData totalCount:total];
+        
+        if (completionBlock) {
+            completionBlock(pageResult, nil);
+        }
+    } failureBlock:^(AOError *error) {
          if (completionBlock) {
              completionBlock(nil, error);
          }
      }];
 }
 
-- (void) allEntries:(void (^)(AOPageResult *result, AOError *err))completionBlock
-{
+- (void) allEntries:(void (^)(AOPageResult *result, AOError *err))completionBlock {
     AOCMSOptionalParams *params = [AOCMSOptionalParams params];
     [self allEntriesForParams:params onComplete:completionBlock];
 }
 
-- (void) allEntriesForParams:(AOCMSOptionalParams *)params onComplete:(void (^)(AOPageResult *result, AOError *err))completionBlock
-{
+- (void) allEntriesForParams:(AOCMSOptionalParams *)params onComplete:(void (^)(AOPageResult *result, AOError *err))completionBlock {
+
     NSMutableDictionary * paramsDict = [params paramsDictionary];
     
-    [self.service sendAuthenticatedGETRequest:kPathContents queryParams:paramsDict allowCache:NO onSuccess:^(id response)
-     {
-         NSArray * entries = @[];
-         
-         if (response[@"entries"]) {
-             entries = response[@"entries"];
-         }
-         
-         AOPageData * pageData = nil;
-         
-         NSUInteger total = [entries count];
-         
-         if (response[@"pagination"]) {
-             total             = [response[@"pagination"][@"total"] unsignedLongValue];
-             NSUInteger offset = [response[@"pagination"][@"offset"] unsignedLongValue];
-             NSUInteger size   = [response[@"pagination"][@"size"] unsignedLongValue];
-             
-             pageData = [AOPageData pageDataWithOffset:offset pageSize:size];
-         }
-         
-         AOPageResult * pageResult = [AOPageResult pageResultWithContent:entries pageData:pageData totalCount:total];
-         
-         if (completionBlock) {
-             completionBlock(pageResult, nil);
-         }
-     }
-                         failureBlock:^(AOError *error)
-     {
+    [self.service sendAuthenticatedGETRequest:kPathContents queryParams:paramsDict allowCache:NO onSuccess:^(id response) {
+        NSArray * entries = @[];
+        
+        if (response[@"entries"]) {
+            entries = response[@"entries"];
+        }
+        
+        AOPageData * pageData = nil;
+        
+        NSUInteger total = [entries count];
+        
+        if (response[@"pagination"]) {
+            total             = [response[@"pagination"][@"total"] unsignedLongValue];
+            NSUInteger offset = [response[@"pagination"][@"offset"] unsignedLongValue];
+            NSUInteger size   = [response[@"pagination"][@"size"] unsignedLongValue];
+            
+            pageData = [AOPageData pageDataWithOffset:offset pageSize:size];
+        }
+        
+        AOPageResult * pageResult = [AOPageResult pageResultWithContent:entries pageData:pageData totalCount:total];
+        
+        if (completionBlock) {
+            completionBlock(pageResult, nil);
+        }
+    } failureBlock:^(AOError *error) {
          if (completionBlock) {
              completionBlock(nil, error);
          }
      }];
 }
 
--(void) localesOnComplete:(nullable void (^)(NSArray *_Nullable locales, AOError *_Nullable err))completionBlock
-{
-    if (self.service.serviceAvailability == AccedoOneServiceAvailabilityOnline)
-    {
-        [self.service sendAuthenticatedGETRequest:kPathLocales queryParams:nil allowCache:NO onSuccess:^(NSDictionary *response)
-         {
-             [self.service addDictionary:response toOfflineAccedoOneConfigWithKey:kPathLocales];
-             
-             if (completionBlock) {
-                 completionBlock(response[@"locales"], nil);
-             }
-         }
-                             failureBlock:^(AOError *error)
-         {
+-(void) localesOnComplete:(nullable void (^)(NSArray *_Nullable locales, AOError *_Nullable err))completionBlock {
+
+    if (self.service.serviceAvailability == AccedoOneServiceAvailabilityOnline) {
+        [self.service sendAuthenticatedGETRequest:kPathLocales queryParams:nil allowCache:NO onSuccess:^(NSDictionary *response) {
+            [self.service addDictionary:response toOfflineAccedoOneConfigWithKey:kPathLocales];
+            
+            if (completionBlock) {
+                completionBlock(response[@"locales"], nil);
+            }
+        } failureBlock:^(AOError *error) {
              if (completionBlock) {
                  completionBlock(nil, error);
              }
          }];
-    }
-    else
-    {
+    } else {
         NSDictionary * cachedResource = [self.service dictionaryFromOfflineAccedoOneConfigWithKey:kPathLocales];
-        
+
         if (completionBlock) {
             completionBlock(cachedResource[@"locales"], cachedResource[@"locales"] ? nil : [AOError errorWithMessage:@"Offline metadata not present!"]);
         }
     }
 }
 
-#pragma mark - Helpers (entry fetching)
+#pragma mark - Helper (Entry fetching)
+
 //helper used by: entriesForIds, entriesForAliases, entriesForAliasType
 - (void) entriesForList:(nonnull NSArray<__kindof NSString*>*)paramList parameter:(NSString *)param optionalParams:(nullable AOCMSOptionalParams *)params onComplete:(nullable void(^)(NSArray *entries, AOError *err))completionBlock {
     
@@ -231,39 +224,39 @@ static NSString *const kPathLocales          = @"locales";
     
     int offset           = 0;
     int defaultPageSize  = 50; //AccedoOne max...
-    int calculatedLength = params.size ? [params.size intValue] : defaultPageSize;
+    int calculatedLength = params.size != nil ? [params.size intValue] : defaultPageSize;
     long length          = MIN (calculatedLength, totalCount); // just to make sure, we do not fetch more than what we have...
     
     __block NSMutableArray* result = [NSMutableArray arrayWithCapacity:totalCount];
     __block AOError * blockError = Nil;
-    for (long i = offset; i < totalCount; i += length)
-    {
+
+    for (long i = offset; i < totalCount; i += length) {
+
         NSArray *paramsToProcess = [paramList subarrayWithRange:NSMakeRange(offset, length)];
         NSString *contentIdsStr  = [paramsToProcess componentsJoinedByString:@","];
         
         NSMutableDictionary *paramsDict = [params paramsDictionary];
         paramsDict[param]     = contentIdsStr; //param could be: "id", "alies", "typeAlias".
-        paramsDict[@"offset"] = params.offset ? params.offset : @(offset);
-        paramsDict[@"size"]   = params.size   ? params.size   : @(defaultPageSize);
+        paramsDict[@"offset"] = params.offset != nil ? params.offset : @(offset);
+        paramsDict[@"size"]   = params.size != nil ? params.size : @(defaultPageSize);
         
         AOAsynchBlockOperation *operation = [AOAsynchBlockOperation new];
         __weak AOAsynchBlockOperation *weakOp = operation;
         
-        [operation addOperationBlock:^
-         {
-             [self.service sendAuthenticatedGETRequest:kPathContents queryParams:paramsDict allowCache:NO onSuccess:^(id response) {
-                 if (response[@"entries"]) {
-                     [result addObjectsFromArray:response[@"entries"]];
-                 }
-                 //NSLog(@"total count: %d, entry count: %d", totalCount, result.count);
-                 
-                 [weakOp markAsFinished];
-             } failureBlock:^(AOError *error) {
-                 blockError = error;
-                 [weakOp markAsFinished];
-             }];
-         }];
-        
+        [operation addOperationBlock:^{
+            [self.service sendAuthenticatedGETRequest:kPathContents queryParams:paramsDict allowCache:NO onSuccess:^(id response) {
+                if (response[@"entries"]) {
+                    [result addObjectsFromArray:response[@"entries"]];
+                }
+                //NSLog(@"total count: %d, entry count: %d", totalCount, result.count);
+                
+                [weakOp markAsFinished];
+            } failureBlock:^(AOError *error) {
+                blockError = error;
+                [weakOp markAsFinished];
+            }];
+        }];
+
         [self.queue addOperation:operation];
         
         offset += length;
@@ -276,8 +269,7 @@ static NSString *const kPathLocales          = @"locales";
         [_queue waitUntilAllOperationsAreFinished];
         
         dispatch_async(dispatch_get_main_queue(), ^{
-            
-            
+
             NSString *entriesCacheKey = [NSString stringWithFormat:@"%@-%@-%@", kPathContents, [paramList componentsJoinedByString:@"+"], [params stringValue]];
             //cache for AccedoOne offline usage...
             if (result.count > 0) {
@@ -294,7 +286,6 @@ static NSString *const kPathLocales          = @"locales";
                     completionBlock(cachedResource[@"kOfflineEntries"], cachedResource ? nil : resultError );
                 }
             }
-            
         });
     });
 }

--- a/Common/API/AccedoOneUserData.h
+++ b/Common/API/AccedoOneUserData.h
@@ -8,28 +8,13 @@
 //
 
 #import <Foundation/Foundation.h>
-
-
+#import "AccedoOneUserDataProtocol.h"
 
 @class AccedoOne;
 @class AOError;
-/**
- * Scope for getting/storing UserData from AccedoOne
- */
-typedef NS_ENUM(NSUInteger, AOUserDataScope) {
-    AOUserDataScopeApplication,
-    AOUserDataScopeApplicationGroup
-};
 
+@interface AccedoOneUserData : NSObject <AccedoOneUserDataProtocol>
 
-@interface AccedoOneUserData : NSObject
--(instancetype _Nonnull ) initWithService:(AccedoOne *_Nonnull) service;
-
-- (void) allDataForUser:(nonnull NSString *)userId scope:(AOUserDataScope)scope onComplete:(nullable void (^)(NSDictionary * _Nullable userData, AOError * _Nullable err))completionBlock;
-- (void) storeData:(nonnull NSDictionary *)data forUser:(nonnull NSString *)userId scope:(AOUserDataScope)scope onComplete:(nullable void(^)(AOError * _Nullable err))completionBlock;
-- (void) dataForUser:(nonnull NSString *)userId key:(nonnull NSString *)key scope:(AOUserDataScope)scope onComplete:(nullable void(^)(NSString * _Nullable value, AOError * _Nullable err))completionBlock;
-- (void) storeValue:(nonnull NSString *)value key:(nonnull NSString *)key forUser:(nonnull NSString *)userId scope:(AOUserDataScope)scope onComplete:(nullable void(^)(AOError * _Nullable err))completionBlock;
+- (instancetype _Nonnull) initWithService:(AccedoOne *_Nonnull) service;
 
 @end
-
-

--- a/Common/API/AccedoOneUserData.m
+++ b/Common/API/AccedoOneUserData.m
@@ -13,9 +13,10 @@
 static NSString *const kPathUserDataApp      = @"user";
 static NSString *const kPathUserDataAppGroup = @"group";
 
-@interface AccedoOneUserData ()
+@interface AccedoOneUserData()
 @property (nonatomic, strong) AccedoOne * service;
 @end
+
 
 @implementation AccedoOneUserData
 
@@ -26,18 +27,17 @@ static NSString *const kPathUserDataAppGroup = @"group";
     return self;
 }
 
+#pragma mark - AccedoOneUserDataProtocol
+
 - (void) allDataForUser:(NSString *)userId scope:(AOUserDataScope)scope onComplete:(void (^)(NSDictionary *userData, AOError *err))completionBlock {
     
     NSString *requestPath = [[self pathForScope:scope] stringByAppendingPathComponent: userId];
     
-    [self.service sendAuthenticatedGETRequest:requestPath queryParams:nil allowCache:NO onSuccess:^(NSDictionary *response)
-     {
+    [self.service sendAuthenticatedGETRequest:requestPath queryParams:nil allowCache:NO onSuccess:^(NSDictionary *response) {
          if (completionBlock) {
              completionBlock(response, nil);
          }
-     }
-                         failureBlock:^(AOError *error)
-     {
+    } failureBlock:^(AOError *error) {
          if (completionBlock) {
              completionBlock(nil, error);
          }
@@ -45,21 +45,17 @@ static NSString *const kPathUserDataAppGroup = @"group";
 }
 
 - (void) storeData:(NSDictionary *)data forUser:(NSString *)userId scope:(AOUserDataScope)scope onComplete:(void(^)(AOError *err))completionBlock {
-    
+
     NSString *requestPath = [[self pathForScope:scope] stringByAppendingPathComponent: userId];
-    
     NSData * body = [NSJSONSerialization dataWithJSONObject:data options:0 error:nil];
-    
+
     [self.service setHeaderValue:@"application/json; charset=utf-8" headerField:@"Content-Type"];
     
-    [self.service sendAuthenticatedPOSTRequest:requestPath params:nil body:body onSuccess:^(id response)
-     {
+    [self.service sendAuthenticatedPOSTRequest:requestPath params:nil body:body onSuccess:^(id response) {
          if (completionBlock) {
              completionBlock(nil);
          }
-     }
-                             onFailure:^(AOError *error)
-     {
+    } onFailure:^(AOError *error) {
          if (completionBlock) {
              completionBlock(error);
          }
@@ -67,25 +63,19 @@ static NSString *const kPathUserDataAppGroup = @"group";
 }
 
 - (void) dataForUser:(NSString *)userId key:(NSString *)key scope:(AOUserDataScope)scope onComplete:(void(^)(NSString *value, AOError *err))completionBlock {
-    
+
     NSString *requestPath = [NSString pathWithComponents: @[[self pathForScope:scope], userId, key]];
     
-    [self.service sendAuthenticatedGETRequest:requestPath queryParams:nil allowCache:NO onSuccess:^(id response)
-     {
+    [self.service sendAuthenticatedGETRequest:requestPath queryParams:nil allowCache:NO onSuccess:^(id response) {
          if (completionBlock) {
              completionBlock(response, nil);
          }
-     }
-                         failureBlock:^(AOError *error)
-     {
-         if (error.code == 200 && error.responseObject) //hack solution, as response is not a JSON but a plain string...
-         {
+     } failureBlock:^(AOError *error) {
+         if (error.code == 200 && error.responseObject) { //hack solution, as response is not a JSON but a plain string...
              if (completionBlock) {
                  completionBlock(error.responseObject, nil);
              }
-         }
-         else
-         {
+         } else {
              if (completionBlock) {
                  completionBlock(nil, error);
              }
@@ -100,14 +90,11 @@ static NSString *const kPathUserDataAppGroup = @"group";
     
     [self.service setHeaderValue:@"text/plain; charset=utf-8" headerField:@"Content-Type"];
     
-    [self.service sendAuthenticatedPOSTRequest:requestPath params:nil body:body onSuccess:^(id response)
-     {
+    [self.service sendAuthenticatedPOSTRequest:requestPath params:nil body:body onSuccess:^(id response) {
          if (completionBlock) {
              completionBlock(nil);
          }
-     }
-                             onFailure:^(AOError *error)
-     {
+    } onFailure:^(AOError *error) {
          if (completionBlock) {
              completionBlock(error);
          }
@@ -118,12 +105,10 @@ static NSString *const kPathUserDataAppGroup = @"group";
 
 - (NSString *) pathForScope:(AOUserDataScope)scope {
     switch (scope) {
-        case AOUserDataScopeApplication:      return kPathUserDataApp;
+        case AOUserDataScopeApplication: return kPathUserDataApp;
         case AOUserDataScopeApplicationGroup: return kPathUserDataAppGroup;
         default: return nil;
     }
 }
-
-
 
 @end

--- a/Common/AccedoOne.h
+++ b/Common/AccedoOne.h
@@ -10,21 +10,20 @@
 #import <Foundation/Foundation.h>
 
 #import "AOService.h"
-#import "AccedoOneInsight.h"
+
+#import "AccedoOneControl.h"
 #import "AccedoOneDetect.h"
+#import "AccedoOneInsight.h"
+#import "AccedoOnePublish.h"
 #import "AccedoOneUserData.h"
+
+#import "AccedoOneCacheProtocol.h"
 #import "AOCMSOptionalParams.h"
 
-
-
-
-
-typedef NS_ENUM(NSUInteger, AccedoOneServiceAvailability)
-{
+typedef NS_ENUM(NSUInteger, AccedoOneServiceAvailability) {
     AccedoOneServiceAvailabilityOnline,
     AccedoOneServiceAvailabilityOffline
 };
-
 
 /**
  * Application Status constants
@@ -32,11 +31,10 @@ typedef NS_ENUM(NSUInteger, AccedoOneServiceAvailability)
 extern NSString * _Nonnull const AOApplicationStateActive;
 extern NSString * _Nonnull const AOApplicationStateMaintenance;
 
-
 /**
  * AccedoOne is the implementation of Accedo's AccedoOne REST API
  */
-@interface AccedoOne : NSObject
+@interface AccedoOne : NSObject <AccedoOneControlProtocol, AccedoOneDetectProtocol, AccedoOneInsightProtocol, AccedoOnePublishProtocol, AccedoOneUserDataProtocol, AccedoOneCacheProtocol>
 
 #pragma mark - Lifecycle
 
@@ -47,73 +45,8 @@ extern NSString * _Nonnull const AOApplicationStateMaintenance;
 - (instancetype _Nonnull ) initWithURL:(nonnull NSString *)url appKey:(nonnull NSString *)appKey userID:(nonnull NSString *)uuid;
 - (instancetype _Nonnull ) initWithURL:(nonnull NSString *)url appKey:(nonnull NSString *)appKey userID:(nonnull NSString *)uuid requestTimeout:(NSTimeInterval)requestTimeout;
 
-#pragma mark - Application Status
+#pragma mark - AccedoOne
 
-- (void) applicationStatus:(nullable void (^)(NSString * _Nullable status, NSString * _Nullable message, AOError * _Nullable err))completionBlock;
-
-#pragma mark - Metadata
-
-- (void) allMetadata:(nullable void (^)(NSDictionary * _Nullable allMetadata, AOError * _Nullable err))completionBlock;
-- (void) allMetadataForGID:(nullable NSString *)gid onComplete:(nullable void (^)(NSDictionary * _Nullable allMetadata, AOError * _Nullable err))completionBlock;
-
-- (void) metadataForKey:(nonnull NSString *)key onComplete:(nullable void (^)(id _Nullable metadata, AOError * _Nullable error))completionBlock;
-- (void) metadataForKey:(nonnull NSString *)key gid:(nullable NSString *)gid onComplete:(nullable void (^)(id _Nullable metadata, AOError * _Nullable error))completionBlock;
-- (void) metadataForKeys:(nonnull NSArray<NSString *>*)keys gid:(nullable NSString *)gid onComplete:(nullable void (^)(id _Nullable metadata, AOError * _Nullable error))completionBlock;
-
-#pragma mark - Profile Information
-
-- (void) profileInfo:(nullable void (^)(NSDictionary* _Nullable profileInfo, AOError* _Nullable err))completionBlock;
-- (void) profileInfoForGID:(nullable NSString*)gid onComplete:(nullable void (^)(NSDictionary* _Nullable profileInfo, AOError* _Nullable err))completionBlock;
-
-#pragma mark - Assets
-
-- (void) allAssets:(nullable void (^)(NSDictionary * _Nullable assetsMetadata, AOError * _Nullable err))completionBlock;
-- (void) assetForKey:(nonnull NSString *)key onComplete:(nullable void (^)(NSData * _Nullable asset, AOError * _Nullable err))completionBlock;
-
-#pragma mark - Content Entry Information (CMS)
-
-- (void) entryForId:(nonnull NSString*)entryId onComplete:(nullable void (^)(NSDictionary * _Nullable entry, AOError * _Nullable err))completionBlock;
-- (void) entryForId:(nonnull NSString*)entryId optionalParams:(nullable AOCMSOptionalParams *)params onComplete:(nullable void (^)(NSDictionary * _Nullable entry, AOError * _Nullable err))completionBlock;
-
-- (void) entriesForIds:(nonnull NSArray<__kindof NSString*>*)contentIds onComplete:(nullable void (^)(NSArray * _Nullable entries, AOError * _Nullable err))completionBlock;
-- (void) entriesForIds:(nonnull NSArray<__kindof NSString*>*)contentIds optionalParams:(nullable AOCMSOptionalParams *)params onComplete:(nullable void(^)(NSArray * _Nullable entries, AOError * _Nullable err))completionBlock;
-
-- (void) entriesForAliases:(nonnull NSArray<__kindof NSString*>*)aliases onComplete:(nullable void (^)(NSArray * _Nullable entries, AOError * _Nullable err))completionBlock;
-- (void) entriesForAliases:(nonnull NSArray<__kindof NSString*>*)aliases optionalParams:(nullable AOCMSOptionalParams *)params onComplete:(nullable void(^)(NSArray * _Nullable entries, AOError * _Nullable err))completionBlock;
-
-- (void) entriesForTypeAlias:(nonnull NSString*)alias onComplete:(nullable void (^)(NSArray * _Nullable entries, AOError * _Nullable err))completionBlock;
-- (void) entriesForTypeAlias:(nonnull NSString*)alias optionalParams:(nullable AOCMSOptionalParams *)params onComplete:(nullable void(^)(NSArray * _Nullable entries, AOError * _Nullable err))completionBlock;
-
-- (void) entriesForType:(nonnull NSString *)typeId onComplete:(nullable void (^)(AOPageResult * _Nullable result, AOError * _Nullable err))completionBlock;
-- (void) entriesForType:(nonnull NSString *)typeId optionalParams:(nullable AOCMSOptionalParams *)params onComplete:(nullable void(^)(AOPageResult * _Nullable result, AOError * _Nullable err))completionBlock;
-
-- (void) allEntries:(nullable void (^)(AOPageResult * _Nullable result, AOError * _Nullable err))completionBlock;
-- (void) allEntriesForParams:(nonnull AOCMSOptionalParams *)params onComplete:(nullable void (^)(AOPageResult * _Nullable result, AOError * _Nullable err))completionBlock;
-
-#pragma mark - Logging (Analytics)
-
-- (void) applicationStart;
-- (void) applicationStartSuccess:(nullable AOSuccessBlock)completionBlock onFailure:(nullable AOErrorBlock)failureBlock;
-
-- (void) applicationStop;
-- (void) applicationStop:(BOOL)clearCache;
-
-#pragma mark - Logging (Remote)
-
-- (void) logWithLevel:(AOServiceLogLevel)logLevel code:(NSUInteger)code message:(NSString *_Nullable)message dimensions:(NSDictionary * _Nullable)dimensions;
-
-#pragma mark - User Data
-
-- (void) allDataForUser:(nonnull NSString *)userId scope:(AOUserDataScope)scope onComplete:(nullable void (^)(NSDictionary * _Nullable userData, AOError * _Nullable err))completionBlock;
-- (void) storeData:(nonnull NSDictionary *)data forUser:(nonnull NSString *)userId scope:(AOUserDataScope)scope onComplete:(nullable void(^)(AOError * _Nullable err))completionBlock;
-- (void) dataForUser:(nonnull NSString *)userId key:(nonnull NSString *)key scope:(AOUserDataScope)scope onComplete:(nullable void(^)(NSString * _Nullable value, AOError * _Nullable err))completionBlock;
-- (void) storeValue:(nonnull NSString *)value key:(nonnull NSString *)key forUser:(nonnull NSString *)userId scope:(AOUserDataScope)scope onComplete:(nullable void(^)(AOError * _Nullable err))completionBlock;
-
-#pragma mark - Locale
-
--(void) localesOnComplete:(nullable void (^)(NSArray *_Nullable locales, AOError *_Nullable err))completionBlock;
-
-- (void) clearSession:(BOOL) clearCache;
 - (void) sendAuthenticatedGETRequest:(nonnull NSString *)requestSuffix
                          queryParams:(NSDictionary* _Nullable)params
                           allowCache:(BOOL)allowCache
@@ -126,17 +59,16 @@ extern NSString * _Nonnull const AOApplicationStateMaintenance;
                             onSuccess:(AOSuccessBlock _Nullable)completionBlock
                             onFailure:(AOErrorBlock _Nullable)failureBlock;
 
-#pragma mark - Cache
+- (void) setHeaderValue:(nonnull NSString *)value headerField:(nonnull NSString *)headerField;
 
-- (void) addDictionary:(NSDictionary *_Nonnull) dictionary toOfflineAccedoOneConfigWithKey:(NSString *_Nonnull) key;
-- (NSDictionary *_Nullable) dictionaryFromOfflineAccedoOneProfileWithKey:(NSString *_Nonnull) key;
-- (NSDictionary *_Nullable) dictionaryFromOfflineAccedoOneConfigWithKey:(NSString *_Nonnull) key;
-- (NSString *_Nullable) ifModifiedSinceDateForCachedObject:(NSString *_Nonnull)cacheKey cache:(id  <AOCacheHandler> _Nonnull) cache;
-- (void) setHeaderValue:(nonnull NSString *) value headerField:(nonnull NSString *) headerField;
+- (void) clearSession:(BOOL)clearCache;
 
-@property (nonatomic, assign) AccedoOneServiceAvailability serviceAvailability;
+#pragma mark - Properties
+
 @property (nonatomic, strong, readonly) NSString * _Nonnull accedoOneURL;
-@property (assign, readonly) NSTimeInterval requestTimeout;
+@property (nonatomic, assign, readonly) NSTimeInterval requestTimeout;
+@property (nonatomic, assign) AccedoOneServiceAvailability serviceAvailability;
+
 @end
 
 

--- a/Common/Cache/AOService+CacheController.m
+++ b/Common/Cache/AOService+CacheController.m
@@ -121,7 +121,7 @@
     {
         if ([self.cacheHandler conformsToProtocol:@protocol(AOTimeBasedCacheHandler)] /*&& request.cacheExpiration*/)
         {
-            NSTimeInterval expiration = request.cacheExpiration ? [request.cacheExpiration doubleValue] : kAODefaultExpirationTime;
+            NSTimeInterval expiration = request.cacheExpiration != nil ? [request.cacheExpiration doubleValue] : kAODefaultExpirationTime;
 
             [(id<AOTimeBasedCacheHandler>)self.cacheHandler setObject:result forKey:request.cacheKey withTimeStamp:[[NSDate date] timeIntervalSince1970] withExpirationInterval:expiration];
         }

--- a/Common/Protocols/AccedoOneCacheProtocol.h
+++ b/Common/Protocols/AccedoOneCacheProtocol.h
@@ -1,0 +1,19 @@
+//
+//  AccedoOneCacheProtocol.h
+//  AccedoOne
+//
+//  Copyright (c) 2018 - present Accedo Broadband AB. All Rights Reserved
+//  Unauthorized copying of this file, via any medium is strictly prohibited
+//  Proprietary and confidential
+//
+
+@class AOCacheHandler;
+
+@protocol AccedoOneCacheProtocol <NSObject>
+
+- (void) addDictionary:(NSDictionary *_Nonnull) dictionary toOfflineAccedoOneConfigWithKey:(NSString *_Nonnull) key;
+- (NSDictionary *_Nullable) dictionaryFromOfflineAccedoOneProfileWithKey:(NSString *_Nonnull) key;
+- (NSDictionary *_Nullable) dictionaryFromOfflineAccedoOneConfigWithKey:(NSString *_Nonnull) key;
+- (NSString *_Nullable) ifModifiedSinceDateForCachedObject:(NSString *_Nonnull)cacheKey cache:(id<AOCacheHandler> _Nonnull) cache;
+
+@end

--- a/Common/Protocols/AccedoOneControlProtocol.h
+++ b/Common/Protocols/AccedoOneControlProtocol.h
@@ -1,0 +1,29 @@
+//
+//  AccedoOneControlProtocol.h
+//  AccedoOne
+//
+//  Copyright (c) 2018 - present Accedo Broadband AB. All Rights Reserved
+//  Unauthorized copying of this file, via any medium is strictly prohibited
+//  Proprietary and confidential
+//
+
+@class AOError;
+
+@protocol AccedoOneControlProtocol <NSObject>
+
+- (void) applicationStatus:(void (^_Nonnull)(NSString * _Nullable status, NSString * _Nullable message,  AOError * _Nullable err))completionBlock;
+
+- (void) profileInfo:(nullable void (^)(NSDictionary* _Nullable profileInfo, AOError* _Nullable err))completionBlock;
+- (void) profileInfoForGID:(nullable NSString*)gid onComplete:(nullable void (^)(NSDictionary* _Nullable profileInfo, AOError* _Nullable err))completionBlock;
+
+- (void) allMetadata:(nullable void (^)(NSDictionary * _Nullable allMetadata, AOError * _Nullable err))completionBlock;
+- (void) allMetadataForGID:(nullable NSString *)gid onComplete:(nullable void (^)(NSDictionary * _Nullable allMetadata, AOError * _Nullable err))completionBlock;
+
+- (void) metadataForKey:(nonnull NSString *)key onComplete:(nullable void (^)(id _Nullable metadata, AOError * _Nullable error))completionBlock;
+- (void) metadataForKey:(nonnull NSString *)key gid:(nullable NSString *)gid onComplete:(nullable void (^)(id _Nullable metadata, AOError * _Nullable error))completionBlock;
+- (void) metadataForKeys:(nonnull NSArray<NSString *>*)keys gid:(nullable NSString *)gid onComplete:(nullable void (^)(id _Nullable metadata, AOError * _Nullable error))completionBlock;
+
+- (void) allAssets:(nullable void (^)(NSDictionary * _Nullable assetsMetadata, AOError *_Nullable err))completionBlock;
+- (void) assetForKey:(nonnull NSString *)key onComplete:(nullable void (^)(NSData * _Nullable asset, AOError * _Nullable err))completionBlock;
+
+@end

--- a/Common/Protocols/AccedoOneDetectProtocol.h
+++ b/Common/Protocols/AccedoOneDetectProtocol.h
@@ -1,0 +1,26 @@
+//
+//  AccedoOneDetectProtocol.h
+//  AccedoOne
+//
+//  Copyright (c) 2018 - present Accedo Broadband AB. All Rights Reserved
+//  Unauthorized copying of this file, via any medium is strictly prohibited
+//  Proprietary and confidential
+//
+
+/**
+ * Log level types used for remote logging
+ */
+typedef NS_ENUM(NSUInteger, AOServiceLogLevel) {
+    AOServiceLogLevelNotInitialized = NSNotFound,
+    AOServiceLogLevelOff            = 0,
+    AOServiceLogLevelError          = 1,
+    AOServiceLogLevelWarn           = 2,
+    AOServiceLogLevelInfo           = 3,
+    AOServiceLogLevelDebug          = 4
+};
+
+@protocol AccedoOneDetectProtocol <NSObject>
+
+- (void) logWithLevel:(AOServiceLogLevel)logLevel code:(NSUInteger)code message:(nonnull  NSString *)message dimensions:(nullable NSDictionary *)dimensions;
+
+@end

--- a/Common/Protocols/AccedoOneInsightProtocol.h
+++ b/Common/Protocols/AccedoOneInsightProtocol.h
@@ -1,0 +1,18 @@
+//
+//  AccedoOneInsightProtocol.h
+//  AccedoOne
+//
+//  Copyright (c) 2018 - present Accedo Broadband AB. All Rights Reserved
+//  Unauthorized copying of this file, via any medium is strictly prohibited
+//  Proprietary and confidential
+//
+
+@protocol AccedoOneInsightProtocol <NSObject>
+
+- (void) applicationStart;
+- (void) applicationStartSuccess:(nullable AOSuccessBlock)completionBlock onFailure:(nullable AOErrorBlock)failureBlock;
+
+- (void) applicationStop;
+- (void) applicationStop:(BOOL)clearCache;
+
+@end

--- a/Common/Protocols/AccedoOnePublishProtocol.h
+++ b/Common/Protocols/AccedoOnePublishProtocol.h
@@ -1,0 +1,36 @@
+//
+//  AccedoOnePublishProtocol.h
+//  AccedoOne
+//
+//  Copyright (c) 2018 - present Accedo Broadband AB. All Rights Reserved
+//  Unauthorized copying of this file, via any medium is strictly prohibited
+//  Proprietary and confidential
+//
+
+@class AOError;
+@class AOCMSOptionalParams;
+@class AOPageResult;
+
+@protocol AccedoOnePublishProtocol <NSObject>
+
+- (void) entryForId:(nonnull NSString*)entryId onComplete:(nullable void (^)(NSDictionary * _Nullable entry, AOError * _Nullable err))completionBlock;
+- (void) entryForId:(nonnull NSString*)entryId optionalParams:(nullable AOCMSOptionalParams *)params onComplete:(nullable void (^)(NSDictionary * _Nullable entry, AOError * _Nullable err))completionBlock;
+
+- (void) entriesForIds:(nonnull NSArray<__kindof NSString*>*)contentIds onComplete:(nullable void (^)(NSArray * _Nullable entries, AOError * _Nullable err))completionBlock;
+- (void) entriesForIds:(nonnull NSArray<__kindof NSString*>*)contentIds optionalParams:(nullable AOCMSOptionalParams *)params onComplete:(nullable void(^)(NSArray * _Nullable entries, AOError * _Nullable err))completionBlock;
+
+- (void) entriesForAliases:(nonnull NSArray<__kindof NSString*>*)aliases onComplete:(nullable void (^)(NSArray * _Nullable entries, AOError * _Nullable err))completionBlock;
+- (void) entriesForAliases:(nonnull NSArray<__kindof NSString*>*)aliases optionalParams:(nullable AOCMSOptionalParams *)params onComplete:(nullable void(^)(NSArray * _Nullable entries, AOError * _Nullable err))completionBlock;
+
+- (void) entriesForTypeAlias:(nonnull NSString*)alias onComplete:(nullable void (^)(NSArray * _Nullable entries, AOError * _Nullable err))completionBlock;
+- (void) entriesForTypeAlias:(nonnull NSString*)alias optionalParams:(nullable AOCMSOptionalParams *)params onComplete:(nullable void(^)(NSArray * _Nullable entries, AOError * _Nullable err))completionBlock;
+
+- (void) entriesForType:(nonnull NSString *)typeId onComplete:(nullable void (^)(AOPageResult * _Nullable result, AOError * _Nullable err))completionBlock;
+- (void) entriesForType:(nonnull NSString *)typeId optionalParams:(nullable AOCMSOptionalParams *)params onComplete:(nullable void(^)(AOPageResult * _Nullable result, AOError * _Nullable err))completionBlock;
+
+- (void) allEntries:(nullable void (^)(AOPageResult * _Nullable result, AOError * _Nullable err))completionBlock;
+- (void) allEntriesForParams:(nonnull AOCMSOptionalParams *)params onComplete:(nullable void (^)(AOPageResult * _Nullable result, AOError * _Nullable err))completionBlock;
+
+- (void) localesOnComplete:(nullable void (^)(NSArray *_Nullable locales, AOError *_Nullable err))completionBlock;
+
+@end

--- a/Common/Protocols/AccedoOneUserDataProtocol.h
+++ b/Common/Protocols/AccedoOneUserDataProtocol.h
@@ -1,0 +1,27 @@
+//
+//  AccedoOneUserDataProtocol.h
+//  AccedoOne
+//
+//  Copyright (c) 2018 - present Accedo Broadband AB. All Rights Reserved
+//  Unauthorized copying of this file, via any medium is strictly prohibited
+//  Proprietary and confidential
+//
+
+@class AOError;
+
+/**
+ * Scope for getting/storing UserData from AccedoOne
+ */
+typedef NS_ENUM(NSUInteger, AOUserDataScope) {
+    AOUserDataScopeApplication,
+    AOUserDataScopeApplicationGroup
+};
+
+@protocol AccedoOneUserDataProtocol <NSObject>
+
+- (void) allDataForUser:(nonnull NSString *)userId scope:(AOUserDataScope)scope onComplete:(nullable void (^)(NSDictionary * _Nullable userData, AOError * _Nullable err))completionBlock;
+- (void) storeData:(nonnull NSDictionary *)data forUser:(nonnull NSString *)userId scope:(AOUserDataScope)scope onComplete:(nullable void(^)(AOError * _Nullable err))completionBlock;
+- (void) dataForUser:(nonnull NSString *)userId key:(nonnull NSString *)key scope:(AOUserDataScope)scope onComplete:(nullable void(^)(NSString * _Nullable value, AOError * _Nullable err))completionBlock;
+- (void) storeValue:(nonnull NSString *)value key:(nonnull NSString *)key forUser:(nonnull NSString *)userId scope:(AOUserDataScope)scope onComplete:(nullable void(^)(AOError * _Nullable err))completionBlock;
+
+@end

--- a/Common/Service/AOCMSOptionalParams.m
+++ b/Common/Service/AOCMSOptionalParams.m
@@ -48,11 +48,11 @@
         dict[@"at"] = [self atDateToString];
     }
 
-    if (self.size) {
+    if (self.size != nil) {
         dict[@"size"] = [self.size stringValue];
     }
 
-    if (self.offset) {
+    if (self.offset != nil) {
         dict[@"offset"] = [self.offset stringValue];
     }
 


### PR DESCRIPTION
Introducing: /Common/Protocols
- AccedoOneCacheProtocol
- AccedoOneControlProtocol
- AccedoOneDetectProtocol
- AccedoOneInsightProtocol
- AccedoOnePublishProtocol
- AccedoOneUserDataProtocol

AccedoOne service implements all above, while each /API component implements its respective interface/protocol.

Results in clean segregated interface.

+Bonus additions: 
- code formatting 
- pragma markings fixed and updated
